### PR TITLE
Move HTTP auth to private method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base # :nodoc:
-  if ENV.key?('HTTP_AUTH_PASSWORD')
-    http_basic_authenticate_with name: 'hackney-foi',
-                                 password: ENV['HTTP_AUTH_PASSWORD']
+  before_action :authenticate
+
+  private
+
+  def authenticate
+    return unless ENV.key?('HTTP_AUTH_PASSWORD')
+    authenticate_or_request_with_http_basic do |name, password|
+      name == 'hackney-foi' && password == ENV['HTTP_AUTH_PASSWORD']
+    end
   end
 end


### PR DESCRIPTION
Specs work in isolation but break when running the whole suite

Having `http_basic_authenticate_with` at a class level meant some specs would fail due to the ENV variable not being present in preceding specs.