### PR TITLE
[#69] Setup and configure Exception Notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'sidekiq'
 gem 'sidekiq-lock'
 gem 'sidekiq-scheduler'
 
+# Error reporting
+gem 'exception_notification'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger
   # console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,9 @@ GEM
     erubi (1.7.1)
     et-orbi (1.1.0)
       tzinfo
+    exception_notification (4.2.2)
+      actionmailer (>= 4.0, < 6)
+      activesupport (>= 4.0, < 6)
     execjs (2.7.0)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
@@ -268,6 +271,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  exception_notification
   factory_bot_rails (~> 4.0)
   govuk_elements_form_builder
   hackney_template!

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'exception_notification/rails'
+require 'exception_notification/sidekiq'
+
+ExceptionNotification.configure do |config|
+  # Ignore additional exception types.
+  # ActiveRecord::RecordNotFound, Mongoid::Errors::DocumentNotFound,
+  # AbstractController::ActionNotFound and ActionController::RoutingError are
+  # already added.
+  # config.ignored_exceptions += %w{ActionView::TemplateError CustomError}
+
+  # Adds a condition to decide when an exception must be ignored or not.
+  # The ignore_if method can be invoked multiple times to add extra conditions.
+  config.ignore_if do |_exception, _options|
+    !Rails.env.production?
+  end
+
+  # Email notifier sends notifications by email.
+  recipients = ENV['EXCEPTION_NOTIFICATIONS_TO']
+  recipients = recipients.split(',').map(&:chomp) if recipients
+
+  config.add_notifier :email,
+                      email_prefix: '[foi-for-councils][ERROR] ',
+                      sender_address: ENV['EXCEPTION_NOTIFICATIONS_FROM'],
+                      exception_recipients: recipients
+end


### PR DESCRIPTION
Fixes #69 

Also enabled notifications within Sidekiq worker jobs.

Requires USER & HOST_URL environment variables to be configured to generate the sender email address. This has been done for our vhost configuation so the sender email will be `foi-for-councils@owl.ukcod.org.uk`