### PR TITLE
Less hacky print button

### DIFF
--- a/app/assets/javascripts/print-button.js
+++ b/app/assets/javascripts/print-button.js
@@ -1,0 +1,7 @@
+var printButtons = document.querySelectorAll('.js-print-button');
+
+for (var i = 0; i < printButtons.length; i++) {
+    printButtons[i].addEventListener('click', function(){
+        window.print();
+    });
+}

--- a/app/assets/stylesheets/print-button.scss
+++ b/app/assets/stylesheets/print-button.scss
@@ -1,0 +1,9 @@
+.js-print-button {
+    display: none;
+}
+
+body.js-enabled {
+    .js-print-button {
+        display: inline-block;
+    }
+}

--- a/app/views/foi/submissions/show.html.erb
+++ b/app/views/foi/submissions/show.html.erb
@@ -54,8 +54,7 @@
     </p>
 
     <p>
-      <%# TODO: Do this properly!! %>
-      <button class="button button-secondary" onclick="window.print()">Print this page</button>
+      <button class="button button-secondary js-print-button">Print this page</button>
     </p>
 
   </div>


### PR DESCRIPTION
Print button no longer uses an inline `onclick=""` attribute.

Fixes #53.