### PR TITLE
[#82] show confirmation email address

### DIFF
--- a/app/views/foi/submissions/show.html.erb
+++ b/app/views/foi/submissions/show.html.erb
@@ -9,7 +9,7 @@
 
     <p class="font-large" style="margin-left: auto; margin-right: auto; max-width: 18em;">
       We will email a reference number to
-      <strong class="bold" id="foi-requestor-email">
+      <strong class="bold">
         <%= @submission.foi_request.contact.email %>
       </strong>
     </p>
@@ -37,7 +37,7 @@
 
     <p class="font-medium">
       We have emailed a copy to
-      <strong class="bold" id="foi-requestor-email">
+      <strong class="bold">
         <%= @submission.foi_request.contact.email %>
       </strong>
     </p>


### PR DESCRIPTION
Fixes #82

Confirm the email address that we're sending the confirmation email to.

![screen shot 2018-05-11 at 10 36 21](https://user-images.githubusercontent.com/282788/39918278-e5599044-5507-11e8-8e9e-dc300d4b8558.png)

![screen shot 2018-05-11 at 10 36 49](https://user-images.githubusercontent.com/282788/39918283-e8498ae8-5507-11e8-8b5c-5b95ace57ac0.png)
