### PR TITLE
[#76] Health endpoint

### DIFF
--- a/app/controllers/health/metrics_controller.rb
+++ b/app/controllers/health/metrics_controller.rb
@@ -9,6 +9,8 @@ module Health
     layout false
 
     def index
+      @submissions_queueable = Submission.queueable.count
+      @submissions_deliverable = Submission.deliverable.count
       @submissions_delivered_unsuccessfully =
         Submission.delivered_unsuccessfully.count
       @sidekiq_stats = Sidekiq::Stats.new

--- a/app/controllers/health/metrics_controller.rb
+++ b/app/controllers/health/metrics_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Health
+  ##
+  # This controller is responsible for providing an overview of system metrics
+  # for internal monitoring checks
+  #
+  class MetricsController < ApplicationController
+    layout false
+
+    def index; end
+  end
+end

--- a/app/controllers/health/metrics_controller.rb
+++ b/app/controllers/health/metrics_controller.rb
@@ -9,6 +9,8 @@ module Health
     layout false
 
     def index
+      @submissions_delivered_unsuccessfully =
+        Submission.delivered_unsuccessfully.count
       @sidekiq_stats = Sidekiq::Stats.new
     end
   end

--- a/app/controllers/health/metrics_controller.rb
+++ b/app/controllers/health/metrics_controller.rb
@@ -8,6 +8,8 @@ module Health
   class MetricsController < ApplicationController
     layout false
 
-    def index; end
+    def index
+      @sidekiq_stats = Sidekiq::Stats.new
+    end
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -19,6 +19,9 @@ class Submission < ApplicationRecord
   scope :delivered_successfully, lambda {
     where(state: DELIVERED).where.not(reference: nil)
   }
+  scope :delivered_unsuccessfully, lambda {
+    where(state: DELIVERED, reference: nil)
+  }
 
   def queue
     QueueSubmission.new(self).call

--- a/app/views/health/metrics/index.text.erb
+++ b/app/views/health/metrics/index.text.erb
@@ -1,3 +1,11 @@
+# HELP app_queuable_submissions Submissions that haven't been queued. A background task should come along and queue these.
+# TYPE app_queuable_submissions gauge
+app_queuable_submissions <%= @submissions_queueable %>
+
+# HELP app_deliverable_submissions Submissions that have been queued. We should always have a Sidekiq job for each deliverable Submission. Deliverable Submissions with no Sidekiq jobs can indicate a problem.
+# TYPE app_deliverable_submissions gauge
+app_deliverable_submissions <%= @submissions_deliverable %>
+
 # HELP app_delivered_unsuccessfully_submissions Submissions we've marked as delivered but haven't received a reference number back from Infreemation.
 # TYPE app_delivered_unsuccessfully_submissions gauge
 app_delivered_unsuccessfully_submissions <%= @submissions_delivered_unsuccessfully %>

--- a/app/views/health/metrics/index.text.erb
+++ b/app/views/health/metrics/index.text.erb
@@ -1,0 +1,27 @@
+# HELP sidekiq_processed_jobs The total number of processed jobs.
+# TYPE sidekiq_processed_jobs gauge
+sidekiq_processed_job <%= @sidekiq_stats.processed %>
+
+# HELP sidekiq_busy_workers The number of workers performing a job.
+# TYPE sidekiq_busy_workers gauge
+sidekiq_busy_workers  <%= @sidekiq_stats.workers_size %>
+
+# HELP sidekiq_enqueued_jobs The number of enqueued jobs waiting to be processed.
+# TYPE sidekiq_enqueued_jobs gauge
+sidekiq_enqueued_jobs <%= @sidekiq_stats.enqueued %>
+
+# HELP sidekiq_retry_jobs The number of failed jobs scheduled for a retry.
+# TYPE sidekiq_retry_jobs gauge
+sidekiq_retry_jobs <%= @sidekiq_stats.retry_size %>
+
+# HELP sidekiq_scheduled_jobs The number of jobs scheduled for a future execution.
+# TYPE sidekiq_scheduled_jobs gauge
+sidekiq_scheduled_jobs <%= @sidekiq_stats.scheduled_size %>
+
+# HELP sidekiq_failed_jobs The total number of failed jobs; these will be retried automatically.
+# TYPE sidekiq_failed_jobs gauge
+sidekiq_failed_jobs <%= @sidekiq_stats.failed %>
+
+# HELP sidekiq_processed_jobs Number of jobs that need manual intervention to retry
+# TYPE sidekiq_dead_jobs gauge
+sidekiq_dead_jobs <%= @sidekiq_stats.dead_size %>

--- a/app/views/health/metrics/index.text.erb
+++ b/app/views/health/metrics/index.text.erb
@@ -1,3 +1,7 @@
+# HELP app_delivered_unsuccessfully_submissions Submissions we've marked as delivered but haven't received a reference number back from Infreemation.
+# TYPE app_delivered_unsuccessfully_submissions gauge
+app_delivered_unsuccessfully_submissions <%= @submissions_delivered_unsuccessfully %>
+
 # HELP sidekiq_processed_jobs The total number of processed jobs.
 # TYPE sidekiq_processed_jobs gauge
 sidekiq_processed_job <%= @sidekiq_stats.processed %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
 
   namespace :health do
     root to: redirect('/health/metrics')
-    resources :metrics, only: [:index]
+    resources :metrics, only: [:index], format: 'txt'
   end
 
   resolve('FoiRequest') { %i[foi request] }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Rails.application.routes.draw do
     resources :curated_links, except: [:show]
   end
 
+  namespace :health do
+    root to: redirect('/health/metrics')
+    resources :metrics, only: [:index]
+  end
+
   resolve('FoiRequest') { %i[foi request] }
 
   mount Sidekiq::Web => '/sidekiq'

--- a/spec/controllers/health/metrics_controller_spec.rb
+++ b/spec/controllers/health/metrics_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Health::MetricsController, type: :controller do
+  describe 'GET #index' do
+    subject { get :index }
+
+    it 'returns http success' do
+      is_expected.to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/health/metrics_controller_spec.rb
+++ b/spec/controllers/health/metrics_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Health::MetricsController, type: :controller do
   describe 'GET #index' do
-    subject { get :index }
+    subject { get :index, format: 'text' }
 
     it 'returns http success' do
       is_expected.to have_http_status(200)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe Submission, type: :model do
       subject { Submission.delivered_successfully }
       it { is_expected.to match_array [delivered_successfully] }
     end
+
+    describe '.delivered_unsuccessfully' do
+      subject { Submission.delivered_unsuccessfully }
+      it { is_expected.to match [delivered] }
+    end
   end
 
   describe '#queue' do

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'health namespace', type: :request do
+  describe 'GET /health' do
+    it 'redirects to metrics index' do
+      get '/health'
+      expect(response).to redirect_to('/health/metrics')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #76 

Initial metrics endpoint. Covers the main Sidekiq stats, and a stat to check that we're getting reference numbers back from the Infreemation API.

![screen shot 2018-05-11 at 15 52 54](https://user-images.githubusercontent.com/282788/39930754-76e852a4-5533-11e8-97ec-00c61d2e2668.png)
