### PR TITLE
Use sendmail for delivering emails

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,6 +80,9 @@ Rails.application.configure do
   # raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  # Use sendmail for delivering emails
+  config.action_mailer.delivery_method = :sendmail
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true


### PR DESCRIPTION
Fixes #88 

Tested on staging by manually setting this within the a Rails console and triggering an error.

