### PR TITLE
Add Procfile and shoreman

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb -p 3000
+queue: bundle exec sidekiq

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,7 @@ Vagrant.configure('2') do |config|
     Log into the Vagrant box with \`vagrant ssh\`
       Run the test suite by \`./bin/rake\`
       Start Rails server by \`./bin/rails server\`
+      Start all app processes with \`shoreman\`
     Access the site at http://0.0.0.0:3000.
   EOT
 end

--- a/script/provision-vagrant.sh
+++ b/script/provision-vagrant.sh
@@ -48,6 +48,10 @@ if [ ! -d "$HOME/.gemrc" ]; then
   echo 'gem: --no-ri --no-rdoc' >> ~/.gemrc
 fi
 
+echo 'Installing shoreman'
+sudo curl -o /usr/local/bin/shoreman -sL https://github.com/chrismytton/shoreman/raw/master/shoreman.sh
+sudo chmod 755 /usr/local/bin/shoreman
+
 if ! grep -qe "^cd \\$HOME/app$" "./.bashrc"; then
   echo "cd \\$HOME/app" >> ./.bashrc
 fi


### PR DESCRIPTION
Makes starting all necessary processes easy and just one command.

Used `shoreman` instead of `foreman` because I couldn't figure out how
to add the binstub correctly in a way that both Rails and bundler are
happy with, and we don't use it in production so no real need to add a ruby
dependency here.