### PR TITLE
[#26] Implement Postgres search matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 services:
-  - postgresql
   - redis-server
+addons:
+  postgresql: "9.6"
 rvm: 2.5.1
 cache: bundler
 sudo: false

--- a/app/controllers/foi/suggestions_controller.rb
+++ b/app/controllers/foi/suggestions_controller.rb
@@ -11,7 +11,7 @@ module Foi
     before_action :find_foi_request
 
     def index
-      @suggestions = FoiSuggestion.from_text(@foi_request.body)
+      @suggestions = FoiSuggestion.from_request(@foi_request)
       redirect_to new_foi_request_contact_path if @suggestions.empty?
     end
   end

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -3,8 +3,4 @@
 # Resources added by staff that appear in the Suggestions to users.
 class CuratedLink < ApplicationRecord
   validates :title, :url, presence: true
-
-  def keywords
-    self[:keywords].to_s.split
-  end
 end

--- a/app/services/foi_suggestion.rb
+++ b/app/services/foi_suggestion.rb
@@ -4,7 +4,76 @@
 # Provides suggested resources based on the FOI request made by a user.
 #
 class FoiSuggestion
-  def self.from_text(_text)
-    []
+  def self.from_request(request)
+    sql = <<~SQL
+      SELECT request_matches, relevance, curated_links.*
+      FROM curated_links,
+      LATERAL (#{request_matches}) AS T1(request_matches),
+      LATERAL (#{relevance}) AS T2(relevance)
+      WHERE relevance > 0.5
+      ORDER BY relevance DESC
+      LIMIT 3
+    SQL
+
+    CuratedLink.find_by_sql([sql, request: request])
   end
+
+  # Rank curated links on the request keyword matches against the title, summary
+  # or keywords - with different weighting for each
+  def self.relevance
+    <<~SQL
+      SELECT ts_rank(
+        setweight(to_tsvector(title), 'B') ||
+        setweight(to_tsvector(COALESCE(summary, '')), 'C') ||
+        setweight(to_tsvector(keywords), 'A'),
+        to_tsquery(array_to_string(request_matches, ' & '))
+      )
+    SQL
+  end
+  private_class_method :relevance
+
+  # Aggregate matched keywords wrapped in a <b> tags into an array and giving us
+  # an idea of the intent of the request
+  def self.request_matches
+    <<~SQL
+      SELECT ARRAY_AGG(DISTINCT rm[1])
+      FROM (#{request_headline}) AS T(headline)
+      CROSS JOIN LATERAL regexp_matches(headline, '<b>(.*?)</b>', 'g') AS rm(matches)
+    SQL
+  end
+  private_class_method :request_matches
+
+  # Generate a headline string which wraps matching keywords in a <b> tag. This
+  # includes keyword stems
+  def self.request_headline
+    <<~SQL
+      SELECT ts_headline(LOWER(body), to_tsquery((#{keywords_query})))
+      FROM foi_requests
+      WHERE foi_requests.id = :request
+      LIMIT 1
+    SQL
+  end
+  private_class_method :request_headline
+
+  # Build a query of keywords to be passed into to_tsquery using the OR operator
+  # and the AND operator for two or more words together
+  def self.keywords_query
+    <<~SQL
+      SELECT array_to_string(ARRAY_AGG(
+        '(' || regexp_replace(keyword, '\s+', ' & ', 'g') || ')'
+      ), ' | ')
+      FROM (#{keywords}) AS T(keyword)
+    SQL
+  end
+  private_class_method :keywords_query
+
+  # Get a unique list of all comma separated keywords from current curated links
+  def self.keywords
+    <<~SQL
+      SELECT DISTINCT UNNEST(regexp_split_to_array(keywords, ',\s*'))
+      FROM curated_links _cl
+      WHERE _cl.id = curated_links.id
+    SQL
+  end
+  private_class_method :keywords
 end

--- a/app/views/foi/suggestions/index.html.erb
+++ b/app/views/foi/suggestions/index.html.erb
@@ -5,7 +5,18 @@
   Before you continue, we’ve found these links that might answer your questions
 </h1>
 
-<div class="js-foi-suggestions"></div>
+<div class="js-foi-suggestions">
+  <% @suggestions.each do |suggestion| %>
+    <%= link_to suggestion.url, class: 'foi-suggestion text', target: '_blank' do %>
+      <h3 class="heading-medium"><%= suggestion.title %></h3>
+
+      <% if suggestion.summary %>
+        <p class="excerpt"><%= suggestion.summary %></p>
+      <% end %>
+      <p><span class="link-fake">Open in a new window</span></p>
+    <% end %>
+  <% end %>
+</div>
 
 <hr class="text" style="margin: 2em 0;">
 

--- a/spec/controllers/foi/suggestions_controller_spec.rb
+++ b/spec/controllers/foi/suggestions_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Foi::SuggestionsController, type: :controller do
     context 'there are suggestions' do
       before do
         allow(FoiSuggestion).
-          to receive(:from_text).with(foi_request.body).and_return([double])
+          to receive(:from_request).with(foi_request).and_return([double])
       end
 
       it 'returns http success' do
@@ -29,7 +29,7 @@ RSpec.describe Foi::SuggestionsController, type: :controller do
     context 'there are no suggestions' do
       before do
         allow(FoiSuggestion).
-          to receive(:from_text).with(foi_request.body).and_return([])
+          to receive(:from_request).with(foi_request).and_return([])
       end
 
       it 'redirects to the next step' do

--- a/spec/models/curated_link_spec.rb
+++ b/spec/models/curated_link_spec.rb
@@ -18,28 +18,4 @@ RSpec.describe CuratedLink, type: :model do
       expect(curated_link.errors[:url]).to_not be_empty
     end
   end
-
-  describe '#keywords' do
-    subject { curated_link.keywords }
-
-    context 'when there are keywords' do
-      let(:curated_link) do
-        build_stubbed(:curated_link, keywords: 'budget health')
-      end
-
-      it 'splits on spaces' do
-        is_expected.to eq(%w[budget health])
-      end
-    end
-
-    context 'when there are no keywords' do
-      let(:curated_link) do
-        build_stubbed(:curated_link, keywords: nil)
-      end
-
-      it 'returns an empty Array' do
-        is_expected.to eq([])
-      end
-    end
-  end
 end

--- a/spec/services/foi_suggestion_spec.rb
+++ b/spec/services/foi_suggestion_spec.rb
@@ -3,9 +3,94 @@
 require 'rails_helper'
 
 RSpec.describe FoiSuggestion, type: :service do
-  describe '.from_text' do
-    it 'returns an empty array' do
-      expect(described_class.from_text('An FOI request…')).to be_empty
+  describe '.from_request' do
+    def suggest(body)
+      request = create(:foi_request, body: body)
+      described_class.from_request(request)
+    end
+
+    let!(:l1) { create(:curated_link, keywords: 'housing, budget') }
+    let!(:l2) { create(:curated_link, keywords: 'council tax') }
+
+    it 'returns the matched selections' do
+      s = suggest('What is the budget for housing in 2018?')
+      expect(s).to match [l1]
+
+      matches = s.first.request_matches
+      expect(matches).to match_array %w[housing budget]
+    end
+
+    it 'returns an empty array when there are no matches' do
+      s = suggest('What are the school admissions polices?')
+      expect(s).to be_empty
+    end
+
+    it 'return matches using stemming and ignoring punctuation' do
+      s1 = suggest('House')
+      s2 = suggest('Houses')
+      s3 = suggest('Housed')
+      s4 = suggest('Housing')
+      s5 = suggest('House\'s')
+
+      expect(s1).to match [l1]
+      expect(s2).to match [l1]
+      expect(s3).to match [l1]
+      expect(s4).to match [l1]
+      expect(s5).to match [l1]
+
+      matches1 = s1.first.request_matches
+      matches2 = s2.first.request_matches
+      matches3 = s3.first.request_matches
+      matches4 = s4.first.request_matches
+      matches5 = s5.first.request_matches
+
+      expect(matches1).to match %w[house]
+      expect(matches2).to match %w[houses]
+      expect(matches3).to match %w[housed]
+      expect(matches4).to match %w[housing]
+      expect(matches5).to match %w[house]
+    end
+
+    it 'return ranked array when keywords separated by commas' do
+      s1 = suggest('Give me information on housing budget?')
+      s2 = suggest('Give me houses in my area?')
+      expect(s1).to match [l1]
+      expect(s2).to match [l1]
+
+      rel1 = s1.first.relevance
+      rel2 = s2.first.relevance
+      expect(rel1).to be > rel2
+
+      matches1 = s1.first.request_matches
+      matches2 = s2.first.request_matches
+      expect(matches1).to match_array %w[housing budget]
+      expect(matches2).to match_array %w[houses]
+    end
+
+    it 'return ranked array when keywords separated by spaces' do
+      s1 = suggest('What are the council tax bands?')
+      s2 = suggest('How is my tax spent?')
+      expect(s1).to match [l2]
+      expect(s2).to match [l2]
+
+      rel1 = s1.first.relevance
+      rel2 = s2.first.relevance
+      expect(rel1).to be > rel2
+
+      matches1 = s1.first.request_matches
+      matches2 = s2.first.request_matches
+      expect(matches1).to match_array %w[council tax]
+      expect(matches2).to match_array %w[tax]
+    end
+
+    it 'returns matches to more than one keyword' do
+      s1 = suggest('Council budget')
+      s2 = suggest('Tax budget')
+      s3 = suggest('Council tax budget')
+
+      expect(s1).to match [l1, l2]
+      expect(s2).to match [l1, l2]
+      expect(s3).to match [l2, l1]
     end
   end
 end


### PR DESCRIPTION
Part of #26 

Gives us word stemming and search ranking. Works by pulling out a list
of all keywords from the curated links. The keywords are matched with
the request to determine important words in the request. This word list
can then be used to generate a relevancy rank against the curated links
of which we need a greater than 0.75 match and we pick the top 3.

Tests need expanding. And need to run some performance analysis.