### PR TITLE
[WIP][#26] Add naive FoiSuggestion service

### DIFF
--- a/app/services/foi_suggestion.rb
+++ b/app/services/foi_suggestion.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
+require 'set'
 ##
 # Provides suggested resources based on the FOI request made by a user.
 #
 class FoiSuggestion
-  def self.from_text(_text)
-    []
+  # FIXME: This is a proof-of-concept; it will be really slow in production as
+  # the site scales.
+  def self.from_text(text)
+    text = Set.new(text.split)
+    suggestions = CuratedLink.all.select do |link|
+      text.intersect?(Set.new(link.keywords))
+    end
+    suggestions.take(3)
   end
 end

--- a/app/views/foi/suggestions/index.html.erb
+++ b/app/views/foi/suggestions/index.html.erb
@@ -5,7 +5,18 @@
   Before you continue, we’ve found these links that might answer your questions
 </h1>
 
-<div class="js-foi-suggestions"></div>
+<div class="js-foi-suggestions">
+  <% @suggestions.each do |suggestion| %>
+    <%= link_to suggestion.url, class: 'foi-suggestion text', target: '_blank' do %>
+      <h3 class="heading-medium"><%= suggestion.title %></h3>
+
+      <% if suggestion.summary %>
+        <p class="excerpt"><%= suggestion.summary %></p>
+      <% end %>
+      <p><span class="link-fake">Open in a new window</span></p>
+    <% end %>
+  <% end %>
+</div>
 
 <hr class="text" style="margin: 2em 0;">
 

--- a/spec/services/foi_suggestion_spec.rb
+++ b/spec/services/foi_suggestion_spec.rb
@@ -4,8 +4,23 @@ require 'rails_helper'
 
 RSpec.describe FoiSuggestion, type: :service do
   describe '.from_text' do
-    it 'returns an empty array' do
-      expect(described_class.from_text('An FOI request…')).to be_empty
+    subject { described_class.from_text(text) }
+
+    context 'with matching text and keywords' do
+      let(:text) { 'What is the budget for housing in 2018?' }
+      before { create(:curated_link, keywords: 'housing budget') }
+
+      it 'returns the matched selections' do
+        is_expected.not_to be_empty
+      end
+    end
+
+    context 'with non-matching text and keywords' do
+      let(:text) { 'Give me information on houses' }
+
+      it 'returns an empty array' do
+        is_expected.to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
Requires https://github.com/mysociety/foi-for-councils/pull/109.

* Splits the text and makes a `Set` from it
* Selects any `CuratedLink` where the text intersects with the keywords
  of that link
* Picks the first 3 to display

This is obviosuly just a proof of concept – it would be great if we
could do this at database level.

Also need to improve the styling of the suggestions.

Extracted from #94 for visibility and future reference. Will get superseded by https://github.com/mysociety/foi-for-councils/pull/105.