### PR TITLE
Fix breakage when .vagrant.yml is empty

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ DEFAULTS = {
 
 settings_file_path = File.dirname(__FILE__) + '/.vagrant.yml'
 settings_file = if File.exist?(settings_file_path)
-  YAML.load(File.read(settings_file_path))
+  YAML.load(File.read(settings_file_path)) || {}
 else
   {}
 end


### PR DESCRIPTION
When `.vagrant.yml` exists, but is empty, Vagrant fails to run:

    $ vagrant reload
    There was an error loading a Vagrantfile. The file being loaded
    and the error message are shown below. This is usually caused by
    a syntax error.

    Path: /Users/gareth/Code/foi-for-councils/Vagrantfile
    Line number: 30
    Message: TypeError: no implicit conversion of false into Hash

The problem is that when `.vagrant.yml` is empty, `YAML.load` returns
`false` rather than an empty `Hash`:

    irb(main):033:0> YAML.load(File.read(settings_file_path))
    # => false

This then gets supplied when we try to merge the `DEFAULTS` and the
`settings_file` hashes, causing the exception.

This commit ensures we always get a `Hash` assigned to `settings_file`
in the event that `.vagrant.yml` exists, but is empty.