### PR TITLE
[#26] Extract duplication to partial

### DIFF
--- a/app/views/admin/curated_links/_preview.html.erb
+++ b/app/views/admin/curated_links/_preview.html.erb
@@ -1,0 +1,4 @@
+<div class="curated-link-preview js-curated-link-preview">
+  <h2 class="heading-small">How your link will look</h2>
+  <%= render partial: 'foi/suggestions/suggestion', locals: { suggestion: curated_link } %>
+</div>

--- a/app/views/admin/curated_links/edit.html.erb
+++ b/app/views/admin/curated_links/edit.html.erb
@@ -13,9 +13,6 @@
     <%= render 'form' %>
   </div>
   <div class="column-one-half">
-    <div class="curated-link-preview js-curated-link-preview">
-      <h2 class="heading-small">How your link will look</h2>
-      <%= render partial: 'foi/suggestions/suggestion', locals: { suggestion: @curated_link } %>
-    </div>
+    <%= render partial: 'preview', locals: { curated_link: @curated_link } %>
   </div>
 </div>

--- a/app/views/admin/curated_links/new.html.erb
+++ b/app/views/admin/curated_links/new.html.erb
@@ -13,9 +13,6 @@
     <%= render 'form' %>
   </div>
   <div class="column-one-half">
-    <div class="curated-link-preview js-curated-link-preview">
-      <h2 class="heading-small">How your link will look</h2>
-      <%= render partial: 'foi/suggestions/suggestion', locals: { suggestion: @curated_link } %>
-    </div>
+    <%= render partial: 'preview', locals: { curated_link: @curated_link } %>
   </div>
 </div>


### PR DESCRIPTION
This extracts the "preview" component to its own partial. I think its
okay to have the layout duplication in the different views, as it feels
correct for the template to "own" its layout. The preview (like the
form) is a "component" that we're injecting in to that layout, so I
think it deserves its own template.