### PR TITLE
[#23] Store suggestions

### DIFF
--- a/app/controllers/admin/exports_controller.rb
+++ b/app/controllers/admin/exports_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Admin
+  ##
+  # This controller is responsible for exporting admin data
+  #
+  class ExportsController < AdminController
+    def show
+      respond_to do |format|
+        format.csv  { render csv: CuratedLink.all }
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/findable_foi_request.rb
+++ b/app/controllers/concerns/findable_foi_request.rb
@@ -21,7 +21,7 @@ module FindableFoiRequest
       redirect_if_missing_request
     end
 
-    def foi_request_from_session(scope: FoiRequest)
+    def foi_request_from_session(scope: FoiRequest.all)
       scope.
         includes(:contact).
         references(:contact).

--- a/app/controllers/concerns/findable_foi_request.rb
+++ b/app/controllers/concerns/findable_foi_request.rb
@@ -36,5 +36,9 @@ module FindableFoiRequest
     def store_foi_request_in_session
       session[:request_id] = @foi_request.id
     end
+
+    def current_foi_request?(foi_request)
+      foi_request == foi_request_from_session
+    end
   end
 end

--- a/app/controllers/foi/suggestions_controller.rb
+++ b/app/controllers/foi/suggestions_controller.rb
@@ -11,7 +11,7 @@ module Foi
     before_action :find_foi_request
 
     def index
-      @suggestions = GenerateFoiSuggestion.from_request(@foi_request)
+      @suggestions = FoiSuggestion.from_request(@foi_request)
       redirect_to new_foi_request_contact_path if @suggestions.empty?
     end
   end

--- a/app/controllers/foi/suggestions_controller.rb
+++ b/app/controllers/foi/suggestions_controller.rb
@@ -11,7 +11,7 @@ module Foi
     before_action :find_foi_request
 
     def index
-      @suggestions = FoiSuggestion.from_request(@foi_request)
+      @suggestions = GenerateFoiSuggestion.from_request(@foi_request)
       redirect_to new_foi_request_contact_path if @suggestions.empty?
     end
   end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -5,9 +5,11 @@
 # resources
 #
 class LinksController < ApplicationController
+  include FindableFoiRequest
+
   def show
     suggestion = FoiSuggestion.find(params[:id])
-    suggestion.clicked!
+    suggestion.clicked! if current_foi_request?(suggestion.foi_request)
     redirect_to suggestion.url
   end
 end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+##
+# This controller is responsible for tracking the number of clicks on suggested
+# resources
+#
+class LinksController < ApplicationController
+  def show
+    suggestion = FoiSuggestion.find(params[:id])
+    suggestion.clicked!
+    redirect_to suggestion.url
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 module ApplicationHelper # :nodoc:
+  def link_to_suggestion(suggestion)
+    if controller.is_a?(AdminController)
+      suggestion.url
+    else
+      link_path(suggestion)
+    end
+  end
 end

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -2,5 +2,7 @@
 
 # Resources added by staff that appear in the Suggestions to users.
 class CuratedLink < ApplicationRecord
+  has_many :foi_suggestions, as: :resource, dependent: :destroy
+
   validates :title, :url, presence: true
 end

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -13,7 +13,7 @@ class CuratedLink < ApplicationRecord
   end
 
   def csv_columns
-    %i[id title url keywords shown click_rate answer_rate]
+    %i[id title url keywords shown click_rate answer_rate created_at updated_at]
   end
 
   def as_csv

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -5,4 +5,10 @@ class CuratedLink < ApplicationRecord
   has_many :foi_suggestions, as: :resource, dependent: :destroy
 
   validates :title, :url, presence: true
+
+  delegate :shown, :click_rate, :answer_rate, to: :statistics
+
+  def statistics
+    @statistics ||= OpenStruct.new(foi_suggestions.statistics)
+  end
 end

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -11,4 +11,12 @@ class CuratedLink < ApplicationRecord
   def statistics
     @statistics ||= OpenStruct.new(foi_suggestions.statistics)
   end
+
+  def csv_columns
+    %i[id title url keywords shown click_rate answer_rate]
+  end
+
+  def as_csv
+    csv_columns.map { |column| public_send(column) }
+  end
 end

--- a/app/models/foi_request.rb
+++ b/app/models/foi_request.rb
@@ -7,6 +7,8 @@ class FoiRequest < ApplicationRecord
   belongs_to :contact, optional: true, dependent: :destroy
   belongs_to :submission, optional: true
 
+  has_many :foi_suggestions, dependent: :nullify
+
   validates :body, presence: true
 
   scope :editable, lambda {

--- a/app/models/foi_suggestion.rb
+++ b/app/models/foi_suggestion.rb
@@ -12,4 +12,16 @@ class FoiSuggestion < ApplicationRecord
   def self.from_request(request)
     GenerateFoiSuggestion.from_request(request)
   end
+
+  def self.submitted!
+    transaction { all.find_each(&:submitted!) }
+  end
+
+  def submitted!
+    increment!(:submissions) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def clicked!
+    increment!(:clicks) # rubocop:disable Rails/SkipsModelValidations
+  end
 end

--- a/app/models/foi_suggestion.rb
+++ b/app/models/foi_suggestion.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+##
+# This model represents an suggested answer to an FOI requests
+#
+class FoiSuggestion < ApplicationRecord
+  belongs_to :foi_request, optional: true
+  belongs_to :resource, polymorphic: true
+end

--- a/app/models/foi_suggestion.rb
+++ b/app/models/foi_suggestion.rb
@@ -13,6 +13,20 @@ class FoiSuggestion < ApplicationRecord
     GenerateFoiSuggestion.from_request(request)
   end
 
+  def self.statistics
+    stats = select(
+      'COUNT(*) AS shown',
+      'SUM(CASE WHEN clicks <> 0 THEN 1 END) AS clicks',
+      'SUM(CASE WHEN clicks > 0 AND submissions = 0 THEN 1 END) AS answers'
+    ).to_a.first
+
+    shown = stats.shown
+
+    { shown: shown,
+      click_rate: shown.zero? ? 0.0 : stats.clicks.to_f / shown,
+      answer_rate: shown.zero? ? 0.0 : stats.answers.to_f / shown }
+  end
+
   def self.submitted!
     transaction { all.find_each(&:submitted!) }
   end

--- a/app/models/foi_suggestion.rb
+++ b/app/models/foi_suggestion.rb
@@ -6,4 +6,10 @@
 class FoiSuggestion < ApplicationRecord
   belongs_to :foi_request, optional: true
   belongs_to :resource, polymorphic: true
+
+  delegate :title, :url, :summary, :keywords, to: :resource
+
+  def self.from_request(request)
+    GenerateFoiSuggestion.from_request(request)
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -24,6 +24,7 @@ class Submission < ApplicationRecord
   }
 
   def queue
+    foi_request.foi_suggestions.submitted!
     QueueSubmission.new(self).call
   end
 

--- a/app/services/generate_foi_suggestion.rb
+++ b/app/services/generate_foi_suggestion.rb
@@ -3,7 +3,7 @@
 ##
 # Provides suggested resources based on the FOI request made by a user.
 #
-class FoiSuggestion
+class GenerateFoiSuggestion
   def self.from_request(request)
     sql = <<~SQL
       SELECT request_matches, relevance, curated_links.*

--- a/app/views/admin/curated_links/index.html.erb
+++ b/app/views/admin/curated_links/index.html.erb
@@ -15,6 +15,9 @@
       <%= link_to new_admin_curated_link_path, class: 'button' do %>
         Add a new Curated Link
       <% end %>
+      <%= link_to admin_export_path, class: 'button' do %>
+        Export CSV
+      <% end %>
     </p>
   </div>
 </div>

--- a/app/views/admin/curated_links/index.html.erb
+++ b/app/views/admin/curated_links/index.html.erb
@@ -16,7 +16,7 @@
         Add a new Curated Link
       <% end %>
       <%= link_to admin_export_path, class: 'button' do %>
-        Export CSV
+        Export suggestion statistics CSV
       <% end %>
     </p>
   </div>

--- a/app/views/foi/suggestions/_suggestion.html.erb
+++ b/app/views/foi/suggestions/_suggestion.html.erb
@@ -1,4 +1,4 @@
-<%= link_to suggestion.url, class: 'foi-suggestion js-suggestion-link text', target: '_blank' do %>
+<%= link_to link_path(suggestion), class: 'foi-suggestion js-suggestion-link text', target: '_blank' do %>
   <h3 class="heading-medium js-suggestion-title"><%= suggestion.title %></h3>
   <p class="summary js-suggestion-summary"><%= suggestion.summary %></p>
   <p><span class="link-fake">Open in a new window</span></p>

--- a/app/views/foi/suggestions/_suggestion.html.erb
+++ b/app/views/foi/suggestions/_suggestion.html.erb
@@ -1,4 +1,4 @@
-<%= link_to link_path(suggestion), class: 'foi-suggestion js-suggestion-link text', target: '_blank' do %>
+<%= link_to link_to_suggestion(suggestion), class: 'foi-suggestion js-suggestion-link text', target: '_blank' do %>
   <h3 class="heading-medium js-suggestion-title"><%= suggestion.title %></h3>
   <p class="summary js-suggestion-summary"><%= suggestion.summary %></p>
   <p><span class="link-fake">Open in a new window</span></p>

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do
@@ -7,3 +8,15 @@
 #     https: false
 #   )
 # end
+
+require 'csv'
+
+ActionController::Renderers.add :csv do |objects, _options|
+  csv_string = CSV.generate do |csv|
+    headers = objects.first&.csv_columns
+    csv << headers if headers
+    objects.each { |object| csv << object.as_csv }
+  end
+
+  send_data csv_string, type: Mime[:csv], filename: 'export.csv'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :links, only: %i[show]
+
   namespace :admin do
     root to: redirect('/admin/curated_links')
     resources :curated_links, except: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,11 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: redirect('/admin/curated_links')
-    resources :curated_links, except: [:show]
+    resources :curated_links, except: [:show] do
+      collection do
+        resource :export, only: [:show], format: 'csv'
+      end
+    end
   end
 
   namespace :health do

--- a/db/migrate/20180605112908_create_foi_suggestions.rb
+++ b/db/migrate/20180605112908_create_foi_suggestions.rb
@@ -1,0 +1,14 @@
+class CreateFoiSuggestions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :foi_suggestions do |t|
+      t.references :foi_request
+      t.references :resource, polymorphic: true
+      t.string :request_matches
+      t.decimal :relevance, precision: 7, scale: 6
+      t.integer :clicks, default: 0, null: false
+      t.integer :submissions, default: 0, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_29_111912) do
+ActiveRecord::Schema.define(version: 2018_06_05_112908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,20 @@ ActiveRecord::Schema.define(version: 2018_05_29_111912) do
     t.datetime "updated_at", null: false
     t.index ["contact_id"], name: "index_foi_requests_on_contact_id"
     t.index ["submission_id"], name: "index_foi_requests_on_submission_id"
+  end
+
+  create_table "foi_suggestions", force: :cascade do |t|
+    t.bigint "foi_request_id"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.string "request_matches"
+    t.decimal "relevance", precision: 7, scale: 6
+    t.integer "clicks", default: 0, null: false
+    t.integer "submissions", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["foi_request_id"], name: "index_foi_suggestions_on_foi_request_id"
+    t.index ["resource_type", "resource_id"], name: "index_foi_suggestions_on_resource_type_and_resource_id"
   end
 
   create_table "submissions", force: :cascade do |t|

--- a/spec/controllers/admin/exports_controller_spec.rb
+++ b/spec/controllers/admin/exports_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::ExportsController, type: :controller do
+  let(:session) do
+    { current_user: 123, authenticated_until: (Time.zone.now + 1.hour).to_i }
+  end
+
+  before do
+    allow(User).to receive(:find_by).with(uid: 123).and_return(build(:user))
+  end
+
+  describe 'GET #show' do
+    subject(:response) do
+      get :show, params: { format: 'csv' }, session: session
+    end
+
+    let!(:suggestion) { create(:foi_suggestion) }
+
+    it 'should return a CSV' do
+      is_expected.to have_http_status(200)
+      expect(response.content_type).to eq 'text/csv'
+    end
+
+    it 'should have CSV headers' do
+      lines = response.body.split("\n")
+
+      expect(lines).to include(
+        'id,title,url,keywords,shown,click_rate,answer_rate'
+      )
+    end
+
+    it 'should have CSV data' do
+      link = suggestion.resource
+      lines = response.body.split("\n")
+
+      expect(lines).to include(
+        [link.id, link.title, link.url, link.keywords, link.shown,
+         link.click_rate, link.answer_rate].join(',')
+      )
+    end
+  end
+end

--- a/spec/controllers/admin/exports_controller_spec.rb
+++ b/spec/controllers/admin/exports_controller_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Admin::ExportsController, type: :controller do
       lines = response.body.split("\n")
 
       expect(lines).to include(
-        'id,title,url,keywords,shown,click_rate,answer_rate'
+        'id,title,url,keywords,shown,' \
+        'click_rate,answer_rate,created_at,updated_at'
       )
     end
 
@@ -35,10 +36,10 @@ RSpec.describe Admin::ExportsController, type: :controller do
       link = suggestion.resource
       lines = response.body.split("\n")
 
-      expect(lines).to include(
-        [link.id, link.title, link.url, link.keywords, link.shown,
-         link.click_rate, link.answer_rate].join(',')
-      )
+      expect(lines).to include([
+        link.id, link.title, link.url, link.keywords, link.shown,
+        link.click_rate, link.answer_rate, link.created_at, link.updated_at
+      ].join(','))
     end
   end
 end

--- a/spec/controllers/foi/suggestions_controller_spec.rb
+++ b/spec/controllers/foi/suggestions_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Foi::SuggestionsController, type: :controller do
 
     context 'there are suggestions' do
       before do
-        allow(GenerateFoiSuggestion).
+        allow(FoiSuggestion).
           to receive(:from_request).with(foi_request).and_return([double])
       end
 
@@ -28,7 +28,7 @@ RSpec.describe Foi::SuggestionsController, type: :controller do
 
     context 'there are no suggestions' do
       before do
-        allow(GenerateFoiSuggestion).
+        allow(FoiSuggestion).
           to receive(:from_request).with(foi_request).and_return([])
       end
 

--- a/spec/controllers/foi/suggestions_controller_spec.rb
+++ b/spec/controllers/foi/suggestions_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Foi::SuggestionsController, type: :controller do
 
     context 'there are suggestions' do
       before do
-        allow(FoiSuggestion).
+        allow(GenerateFoiSuggestion).
           to receive(:from_request).with(foi_request).and_return([double])
       end
 
@@ -28,7 +28,7 @@ RSpec.describe Foi::SuggestionsController, type: :controller do
 
     context 'there are no suggestions' do
       before do
-        allow(FoiSuggestion).
+        allow(GenerateFoiSuggestion).
           to receive(:from_request).with(foi_request).and_return([])
       end
 

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -3,24 +3,47 @@
 require 'rails_helper'
 
 RSpec.describe LinksController, type: :controller do
+  include_context 'FOI Request Scope'
+
   describe 'GET #show' do
-    subject { get :show, params: { id: '1' } }
+    subject { get :show, params: { id: '1' }, session: { request_id: '1' } }
 
     let(:suggestion) { build_stubbed(:foi_suggestion) }
+    let(:foi_request) { build_stubbed(:foi_request) }
 
     before do
       allow(FoiSuggestion).to receive(:find).with('1').and_return(suggestion)
       allow(suggestion).to receive(:clicked!)
       allow(suggestion).to receive(:url).and_return('http://example.com')
+
+      allow(foi_request_scope).to receive(:find_by).
+        with(id: '1').and_return(foi_request)
     end
 
-    it 'call clicked! on suggestion' do
-      expect(suggestion).to receive(:clicked!)
-      subject
+    context 'suggestion for current request' do
+      before { suggestion.foi_request = foi_request }
+
+      it 'call clicked! on suggestion' do
+        expect(suggestion).to receive(:clicked!)
+        subject
+      end
+
+      it 'redirects suggestion URL' do
+        is_expected.to redirect_to('http://example.com')
+      end
     end
 
-    it 'redirects suggestion URL' do
-      is_expected.to redirect_to('http://example.com')
+    context 'suggestion for another request' do
+      before { suggestion.foi_request = build_stubbed(:foi_request) }
+
+      it 'does not call clicked! on suggestion' do
+        expect(suggestion).to_not receive(:clicked!)
+        subject
+      end
+
+      it 'redirects suggestion URL' do
+        is_expected.to redirect_to('http://example.com')
+      end
     end
   end
 end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LinksController, type: :controller do
+  describe 'GET #show' do
+    subject { get :show, params: { id: '1' } }
+
+    let(:suggestion) { build_stubbed(:foi_suggestion) }
+
+    before do
+      allow(FoiSuggestion).to receive(:find).with('1').and_return(suggestion)
+      allow(suggestion).to receive(:clicked!)
+      allow(suggestion).to receive(:url).and_return('http://example.com')
+    end
+
+    it 'call clicked! on suggestion' do
+      expect(suggestion).to receive(:clicked!)
+      subject
+    end
+
+    it 'redirects suggestion URL' do
+      is_expected.to redirect_to('http://example.com')
+    end
+  end
+end

--- a/spec/factories/curated_links.rb
+++ b/spec/factories/curated_links.rb
@@ -11,5 +11,11 @@ FactoryBot.define do
       of this curated link.
       TEXT
     end
+
+    factory :curated_link_with_suggestions do
+      after(:create) do |curated_link, _evaluator|
+        create_list(:foi_suggestion, 3, resource: curated_link)
+      end
+    end
   end
 end

--- a/spec/factories/foi_requests.rb
+++ b/spec/factories/foi_requests.rb
@@ -16,5 +16,11 @@ FactoryBot.define do
     trait :delivered do
       association :submission, :delivered, strategy: :build
     end
+
+    factory :foi_request_with_suggestions do
+      after(:create) do |foi_request, _evaluator|
+        create_list(:foi_suggestion, 3, foi_request: foi_request)
+      end
+    end
   end
 end

--- a/spec/factories/foi_suggestions.rb
+++ b/spec/factories/foi_suggestions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :foi_suggestion do
+    association :foi_request, strategy: :build
+    association :resource, factory: :curated_link, strategy: :build
+  end
+end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
         "FOI-#{n}"
       end
     end
+
+    factory :submission_with_foi_request do
+      association :foi_request, strategy: :build
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#link_to_suggestion' do
+    let(:suggestion) do
+      resource = build(:curated_link, url: 'http://example.com/dfg')
+      build_stubbed(:foi_suggestion, id: 1, resource: resource)
+    end
+
+    subject { helper.link_to_suggestion(suggestion) }
+
+    context 'admin controller' do
+      before do
+        allow(controller).to receive(:is_a?).with(AdminController).
+          and_return(true)
+      end
+
+      it 'links directly to suggestion resource' do
+        is_expected.to eq 'http://example.com/dfg'
+      end
+    end
+
+    context 'other controller' do
+      before do
+        allow(controller).to receive(:is_a?).with(AdminController).
+          and_return(false)
+      end
+
+      it 'links to links controller' do
+        is_expected.to eq '/links/1'
+      end
+    end
+  end
+end

--- a/spec/models/curated_link_spec.rb
+++ b/spec/models/curated_link_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe CuratedLink, type: :model do
   let(:curated_link) { build_stubbed(:curated_link) }
 
-  describe 'assoications' do
+  describe 'associations' do
     it 'has many FOI suggestions' do
       expect(curated_link.foi_suggestions.new).to be_a FoiSuggestion
     end

--- a/spec/models/curated_link_spec.rb
+++ b/spec/models/curated_link_spec.rb
@@ -5,6 +5,18 @@ require 'rails_helper'
 RSpec.describe CuratedLink, type: :model do
   let(:curated_link) { build_stubbed(:curated_link) }
 
+  describe 'assoications' do
+    it 'has many FOI suggestions' do
+      expect(curated_link.foi_suggestions.new).to be_a FoiSuggestion
+    end
+
+    it 'removes FOI suggestions on destroy' do
+      curated_link = create(:curated_link_with_suggestions)
+      expect { curated_link.destroy }.to change(FoiSuggestion, :count).
+        from(3).to(0)
+    end
+  end
+
   describe 'attributes' do
     it 'requires a title' do
       curated_link.title = nil

--- a/spec/models/curated_link_spec.rb
+++ b/spec/models/curated_link_spec.rb
@@ -30,4 +30,28 @@ RSpec.describe CuratedLink, type: :model do
       expect(curated_link.errors[:url]).to_not be_empty
     end
   end
+
+  describe 'statistics delegate methods' do
+    before do
+      expect(curated_link).to(
+        receive_message_chain(:foi_suggestions, :statistics).
+        and_return(shown: 3, click_rate: 0.66, answer_rate: 0.33)
+      )
+    end
+
+    describe '#shown' do
+      subject { curated_link.shown }
+      it { is_expected.to eq 3 }
+    end
+
+    describe '#click_rate' do
+      subject { curated_link.click_rate }
+      it { is_expected.to eq 0.66 }
+    end
+
+    describe '#answer_rate' do
+      subject { curated_link.answer_rate }
+      it { is_expected.to eq 0.33 }
+    end
+  end
 end

--- a/spec/models/foi_request_spec.rb
+++ b/spec/models/foi_request_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe FoiRequest, type: :model do
       expect(request.build_submission).to be_a Submission
     end
 
+    it 'has many FOI suggestions' do
+      expect(request.foi_suggestions.new).to be_a FoiSuggestion
+    end
+
     it 'removes Contact on destroy' do
       request = create(:foi_request)
       expect { request.destroy }.to change { Contact.count }.by(-1)
@@ -21,7 +25,14 @@ RSpec.describe FoiRequest, type: :model do
 
     it 'does not remove Submission on destroy' do
       request = create(:foi_request, :unqueued)
+      expect(Submission.count).to eq 1
       expect { request.destroy }.to_not(change { Submission.count })
+    end
+
+    it 'does not remove FOI suggestions on destroy' do
+      request = create(:foi_request_with_suggestions)
+      expect(FoiSuggestion.count).to eq 3
+      expect { request.destroy }.to_not(change { FoiSuggestion.count })
     end
   end
 

--- a/spec/models/foi_suggestion_spec.rb
+++ b/spec/models/foi_suggestion_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe FoiSuggestion, type: :model do
   end
 
   describe '.from_request' do
-    it 'delegate to GenerateFoiSuggestion service' do
+    it 'delegates to GenerateFoiSuggestion service' do
       request = double(:request)
       expect(GenerateFoiSuggestion).to receive(:from_request).with(request)
       described_class.from_request(request)

--- a/spec/models/foi_suggestion_spec.rb
+++ b/spec/models/foi_suggestion_spec.rb
@@ -28,4 +28,41 @@ RSpec.describe FoiSuggestion, type: :model do
       expect { suggestion.destroy }.to_not(change { CuratedLink.count })
     end
   end
+
+  describe 'delegated methods' do
+    let(:resource) do
+      build(:curated_link, title: 'The title', url: 'http://example.com/abc',
+                           summary: 'The summary', keywords: 'foo, bar, baz')
+    end
+
+    before { suggestion.resource = resource }
+
+    describe '#title' do
+      subject { suggestion.title }
+      it { is_expected.to eq 'The title' }
+    end
+
+    describe '#url' do
+      subject { suggestion.url }
+      it { is_expected.to eq 'http://example.com/abc' }
+    end
+
+    describe '#summary' do
+      subject { suggestion.summary }
+      it { is_expected.to eq 'The summary' }
+    end
+
+    describe '#keywords' do
+      subject { suggestion.keywords }
+      it { is_expected.to eq 'foo, bar, baz' }
+    end
+  end
+
+  describe '.from_request' do
+    it 'delegate to GenerateFoiSuggestion service' do
+      request = double(:request)
+      expect(GenerateFoiSuggestion).to receive(:from_request).with(request)
+      described_class.from_request(request)
+    end
+  end
 end

--- a/spec/models/foi_suggestion_spec.rb
+++ b/spec/models/foi_suggestion_spec.rb
@@ -65,4 +65,28 @@ RSpec.describe FoiSuggestion, type: :model do
       described_class.from_request(request)
     end
   end
+
+  describe '.submitted!' do
+    it 'calls submitted! on all instances' do
+      suggestion = create(:foi_suggestion)
+      expect { described_class.submitted! }.to(change do
+        suggestion.reload
+        suggestion.submissions
+      end.by(1))
+    end
+  end
+
+  describe '#submitted!' do
+    it 'increases submissions count' do
+      suggestion = create(:foi_suggestion)
+      expect { suggestion.submitted! }.to change(suggestion, :submissions).by(1)
+    end
+  end
+
+  describe '#clicked!' do
+    it 'increases clicks count' do
+      suggestion = create(:foi_suggestion)
+      expect { suggestion.clicked! }.to change(suggestion, :clicks).by(1)
+    end
+  end
 end

--- a/spec/models/foi_suggestion_spec.rb
+++ b/spec/models/foi_suggestion_spec.rb
@@ -66,6 +66,32 @@ RSpec.describe FoiSuggestion, type: :model do
     end
   end
 
+  describe '.statistics' do
+    subject { described_class.statistics }
+
+    context 'suggestions shown' do
+      before do
+        create(:foi_suggestion, submissions: 1) # neither
+        create(:foi_suggestion, clicks: 2) # click & answer
+        create(:foi_suggestion, clicks: 3, submissions: 1) # click
+      end
+
+      it 'runs SQL query and compile shown count, and click/ anser rates' do
+        is_expected.to match(
+          shown: 3,
+          click_rate: 0.6666666666666666,
+          answer_rate: 0.3333333333333333
+        )
+      end
+    end
+
+    context 'suggestion not shown' do
+      it 'does not return NaN when there has not been any clicks' do
+        is_expected.to match(shown: 0, click_rate: 0.0, answer_rate: 0.0)
+      end
+    end
+  end
+
   describe '.submitted!' do
     it 'calls submitted! on all instances' do
       suggestion = create(:foi_suggestion)

--- a/spec/models/foi_suggestion_spec.rb
+++ b/spec/models/foi_suggestion_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe FoiSuggestion, type: :model do
   let(:suggestion) { build_stubbed(:foi_suggestion) }
 
-  describe 'assoications' do
+  describe 'associations' do
     it 'belongs to a FOI request' do
       expect(suggestion.build_foi_request).to be_a FoiRequest
     end

--- a/spec/models/foi_suggestion_spec.rb
+++ b/spec/models/foi_suggestion_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FoiSuggestion, type: :model do
+  let(:suggestion) { build_stubbed(:foi_suggestion) }
+
+  describe 'assoications' do
+    it 'belongs to a FOI request' do
+      expect(suggestion.build_foi_request).to be_a FoiRequest
+    end
+
+    it 'belongs to a polymorphic resource' do
+      expect(suggestion.resource).to be_a CuratedLink
+      expect(suggestion.resource_id).to be_a Numeric
+      expect(suggestion.resource_type).to eq 'CuratedLink'
+    end
+
+    it 'does not remove FOI request on destroy' do
+      suggestion = create(:foi_suggestion)
+      expect(FoiRequest.count).to eq 1
+      expect { suggestion.destroy }.to_not(change { FoiRequest.count })
+    end
+
+    it 'does not remove resource on destroy' do
+      suggestion = create(:foi_suggestion)
+      expect(CuratedLink.count).to eq 1
+      expect { suggestion.destroy }.to_not(change { CuratedLink.count })
+    end
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -57,6 +57,8 @@ RSpec.describe Submission, type: :model do
   end
 
   describe '#queue' do
+    let(:submission) { build_stubbed(:submission_with_foi_request) }
+
     it 'delegates to QueueSubmission service' do
       service = double(:service)
       expect(QueueSubmission).to receive(:new).with(submission).

--- a/spec/services/generate_foi_suggestion_spec.rb
+++ b/spec/services/generate_foi_suggestion_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe FoiSuggestion, type: :service do
+RSpec.describe GenerateFoiSuggestion, type: :service do
   describe '.from_request' do
     def suggest(body)
       request = create(:foi_request, body: body)

--- a/spec/services/generate_foi_suggestion_spec.rb
+++ b/spec/services/generate_foi_suggestion_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GenerateFoiSuggestion, type: :service do
       expect { suggestion.reload }.to change(suggestion, :relevance)
     end
 
-    it 'iniialise new suggestions' do
+    it 'initialise new suggestions' do
       expect { suggest_all('Council budget') }.to change(FoiSuggestion, :count).
         by(2)
     end

--- a/spec/services/generate_foi_suggestion_spec.rb
+++ b/spec/services/generate_foi_suggestion_spec.rb
@@ -4,24 +4,42 @@ require 'rails_helper'
 
 RSpec.describe GenerateFoiSuggestion, type: :service do
   describe '.from_request' do
-    def suggest(body)
-      request = create(:foi_request, body: body)
+    def suggest_all(body = nil, request: nil)
+      request ||= create(:foi_request, body: body)
       described_class.from_request(request)
+    end
+
+    def suggest(*args)
+      suggest_all(*args).first
     end
 
     let!(:l1) { create(:curated_link, keywords: 'housing, budget') }
     let!(:l2) { create(:curated_link, keywords: 'council tax') }
 
+    it 'finds and updates existing suggestions' do
+      suggestion = create(:foi_suggestion, resource: l1)
+      request = suggestion.foi_request
+      request.update(body: 'Housing budget')
+
+      expect(suggest(request: request)).to eq suggestion
+      expect { suggestion.reload }.to change(suggestion, :relevance)
+    end
+
+    it 'iniialise new suggestions' do
+      expect { suggest_all('Council budget') }.to change(FoiSuggestion, :count).
+        by(2)
+    end
+
     it 'returns the matched selections' do
       s = suggest('What is the budget for housing in 2018?')
-      expect(s).to match [l1]
+      expect(s.resource).to eq l1
 
-      matches = s.first.request_matches
-      expect(matches).to match_array %w[housing budget]
+      matches = s.request_matches
+      expect(matches).to eq 'budget, housing'
     end
 
     it 'returns an empty array when there are no matches' do
-      s = suggest('What are the school admissions polices?')
+      s = suggest_all('What are the school admissions polices?')
       expect(s).to be_empty
     end
 
@@ -32,61 +50,61 @@ RSpec.describe GenerateFoiSuggestion, type: :service do
       s4 = suggest('Housing')
       s5 = suggest('House\'s')
 
-      expect(s1).to match [l1]
-      expect(s2).to match [l1]
-      expect(s3).to match [l1]
-      expect(s4).to match [l1]
-      expect(s5).to match [l1]
+      expect(s1.resource).to eq l1
+      expect(s2.resource).to eq l1
+      expect(s3.resource).to eq l1
+      expect(s4.resource).to eq l1
+      expect(s5.resource).to eq l1
 
-      matches1 = s1.first.request_matches
-      matches2 = s2.first.request_matches
-      matches3 = s3.first.request_matches
-      matches4 = s4.first.request_matches
-      matches5 = s5.first.request_matches
+      matches1 = s1.request_matches
+      matches2 = s2.request_matches
+      matches3 = s3.request_matches
+      matches4 = s4.request_matches
+      matches5 = s5.request_matches
 
-      expect(matches1).to match %w[house]
-      expect(matches2).to match %w[houses]
-      expect(matches3).to match %w[housed]
-      expect(matches4).to match %w[housing]
-      expect(matches5).to match %w[house]
+      expect(matches1).to eq 'house'
+      expect(matches2).to eq 'houses'
+      expect(matches3).to eq 'housed'
+      expect(matches4).to eq 'housing'
+      expect(matches5).to eq 'house'
     end
 
     it 'return ranked array when keywords separated by commas' do
       s1 = suggest('Give me information on housing budget?')
       s2 = suggest('Give me houses in my area?')
-      expect(s1).to match [l1]
-      expect(s2).to match [l1]
+      expect(s1.resource).to eq l1
+      expect(s2.resource).to eq l1
 
-      rel1 = s1.first.relevance
-      rel2 = s2.first.relevance
+      rel1 = s1.relevance
+      rel2 = s2.relevance
       expect(rel1).to be > rel2
 
-      matches1 = s1.first.request_matches
-      matches2 = s2.first.request_matches
-      expect(matches1).to match_array %w[housing budget]
-      expect(matches2).to match_array %w[houses]
+      matches1 = s1.request_matches
+      matches2 = s2.request_matches
+      expect(matches1).to eq 'budget, housing'
+      expect(matches2).to eq 'houses'
     end
 
     it 'return ranked array when keywords separated by spaces' do
       s1 = suggest('What are the council tax bands?')
       s2 = suggest('How is my tax spent?')
-      expect(s1).to match [l2]
-      expect(s2).to match [l2]
+      expect(s1.resource).to eq l2
+      expect(s2.resource).to eq l2
 
-      rel1 = s1.first.relevance
-      rel2 = s2.first.relevance
+      rel1 = s1.relevance
+      rel2 = s2.relevance
       expect(rel1).to be > rel2
 
-      matches1 = s1.first.request_matches
-      matches2 = s2.first.request_matches
-      expect(matches1).to match_array %w[council tax]
-      expect(matches2).to match_array %w[tax]
+      matches1 = s1.request_matches
+      matches2 = s2.request_matches
+      expect(matches1).to eq 'council, tax'
+      expect(matches2).to eq 'tax'
     end
 
     it 'returns matches to more than one keyword' do
-      s1 = suggest('Council budget')
-      s2 = suggest('Tax budget')
-      s3 = suggest('Council tax budget')
+      s1 = suggest_all('Council budget').map(&:resource)
+      s2 = suggest_all('Tax budget').map(&:resource)
+      s3 = suggest_all('Council tax budget').map(&:resource)
 
       expect(s1).to match [l1, l2]
       expect(s2).to match [l1, l2]

--- a/spec/support/context.rb
+++ b/spec/support/context.rb
@@ -13,6 +13,8 @@ RSpec.shared_context 'FOI Request Scope', shared_context: :metadata do
       and_return(foi_request_scope)
     allow(FoiRequest).to receive(:sent).
       and_return(foi_request_scope)
+    allow(FoiRequest).to receive(:all).
+      and_return(foi_request_scope)
 
     allow(foi_request_scope).to receive(:includes).
       with(:contact).and_return(foi_request_scope)


### PR DESCRIPTION
Closes #23 

Added:
- Suggestions displayed to users are now stored in the DB
- Recording when they are clicked or when the user goes on to continue their request
- Postgres query to collate statistics on suggestions
- Statistics CSV export for suggestion resources.
