### PR TITLE
Save current keyword when focus leaves Keywords input

### DIFF
--- a/app/assets/javascripts/keyword-picker.js
+++ b/app/assets/javascripts/keyword-picker.js
@@ -65,6 +65,7 @@ var setUpKeywordPicker = function () {
     placeholder: originalInputPlaceholder,
     tags: originalInputKeywords,
     tabIndex: 0,
+    saveOnBlur: true,
     onTagAdd: function (e, tag){
       saveTagsToInput()
     },


### PR DESCRIPTION
This means, if you type a keyword in the box, but don’t press Enter, then the keyword will get saved before you click the form submit button.

Thanks to @crowbot for spotting this in #114!