### PR TITLE
[#25] Add PublishedRequest model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
 
 Metrics/BlockLength:
   Exclude:
+    - 'spec/factories/*.rb'
     - 'spec/**/*_spec.rb'
     - 'config/routes.rb'
 

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -9,10 +9,15 @@ class PublishedRequest < ApplicationRecord
   private
 
   def update_cached_columns
+    cache_reference
     cache_title
     cache_url
     construct_summary
     cache_keywords
+  end
+
+  def cache_reference
+    self.reference = payload['ref']
   end
 
   def cache_title

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+##
+# A cache of published FOI requests and responses from the disclosure log.
+#
+class PublishedRequest < ApplicationRecord
+end

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -6,6 +6,16 @@
 class PublishedRequest < ApplicationRecord
   before_save :update_cached_columns
 
+  def self.create_or_update_from_api!(attrs)
+    existing = find_by(reference: attrs[:ref])
+
+    if existing
+      existing.update!(payload: attrs)
+    else
+      create!(payload: attrs)
+    end
+  end
+
   private
 
   def update_cached_columns

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -14,6 +14,7 @@ class PublishedRequest < ApplicationRecord
     cache_url
     construct_summary
     cache_keywords
+    parse_published_at
   end
 
   def cache_reference
@@ -43,5 +44,10 @@ class PublishedRequest < ApplicationRecord
 
   def cache_keywords
     self.keywords = payload['keywords']
+  end
+
+  def parse_published_at
+    date = payload['datepublished']
+    self.published_at = Date.parse(date) if date.present?
   end
 end

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -4,4 +4,39 @@
 # A cache of published FOI requests and responses from the disclosure log.
 #
 class PublishedRequest < ApplicationRecord
+  before_save :update_cached_columns
+
+  private
+
+  def update_cached_columns
+    cache_title
+    cache_url
+    construct_summary
+    cache_keywords
+  end
+
+  def cache_title
+    self.title = payload['subject']
+  end
+
+  def cache_url
+    self.url = payload['url']
+  end
+
+  def construct_summary
+    text = payload['requestbody']
+    text += "\n"
+    text += responses.reverse.join("\n")
+    self.summary = text
+  end
+
+  def responses
+    payload['history'].fetch('response', []).map do |response|
+      response['responsebody']
+    end
+  end
+
+  def cache_keywords
+    self.keywords = payload['keywords']
+  end
 end

--- a/db/migrate/20180605151909_create_published_requests.rb
+++ b/db/migrate/20180605151909_create_published_requests.rb
@@ -1,0 +1,9 @@
+class CreatePublishedRequests < ActiveRecord::Migration[5.2]
+  def change
+    create_table :published_requests do |t|
+      t.jsonb :payload
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180605224444_add_cache_columns_to_published_requests.rb
+++ b/db/migrate/20180605224444_add_cache_columns_to_published_requests.rb
@@ -1,0 +1,8 @@
+class AddCacheColumnsToPublishedRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :published_requests, :title, :string
+    add_column :published_requests, :url, :string
+    add_column :published_requests, :summary, :text
+    add_column :published_requests, :keywords, :string
+  end
+end

--- a/db/migrate/20180606003046_add_reference_to_published_requests.rb
+++ b/db/migrate/20180606003046_add_reference_to_published_requests.rb
@@ -1,0 +1,5 @@
+class AddReferenceToPublishedRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :published_requests, :reference, :string
+  end
+end

--- a/db/migrate/20180615085720_add_published_at_to_published_requests.rb
+++ b/db/migrate/20180615085720_add_published_at_to_published_requests.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToPublishedRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :published_requests, :published_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2018_06_06_111720) do
     t.string "url"
     t.text "summary"
     t.string "keywords"
+    t.string "reference"
   end
 
   create_table "submissions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_06_111720) do
+ActiveRecord::Schema.define(version: 2018_06_15_085720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2018_06_06_111720) do
     t.text "summary"
     t.string "keywords"
     t.string "reference"
+    t.datetime "published_at"
   end
 
   create_table "submissions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,6 +60,10 @@ ActiveRecord::Schema.define(version: 2018_06_06_111720) do
     t.jsonb "payload"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
+    t.string "url"
+    t.text "summary"
+    t.string "keywords"
   end
 
   create_table "submissions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,6 +56,12 @@ ActiveRecord::Schema.define(version: 2018_06_06_111720) do
     t.index ["resource_type", "resource_id"], name: "index_foi_suggestions_on_resource_type_and_resource_id"
   end
 
+  create_table "published_requests", force: :cascade do |t|
+    t.jsonb "payload"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "submissions", force: :cascade do |t|
     t.string "state", null: false
     t.datetime "created_at", null: false

--- a/spec/factories/published_requests.rb
+++ b/spec/factories/published_requests.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :published_request do
+    payload do
+      { generated: '2018-06-05 00:00',
+        ref: 'FOI-1',
+        type: 'FOI',
+        datecreated: '2018-01-01',
+        dateclosed: '2018-04-22',
+        datepublished: '2018-04-23',
+        url: 'http://foi.infreemation.co.uk/redirect/hackney?id=1',
+        status: 'Closed',
+        outcome: 'Rejected - Exempt',
+        category: 'Local Businesses',
+        keywords: 'Business, business rates',
+        timespent: { unit: 'minutes', value: '0' },
+        costtorespond: { unit: 'gbp', value: '0' },
+        subject: 'Business Rates',
+        requestbody: 'Initial FOI Request',
+        exemptions: {
+          exemption: 'S(21) - Information accessible by other means'
+        },
+        history: {
+          response: [
+            { responsebody: 'Thank you for your help',
+              from: 'Customer',
+              datetime: '2018-01-04 13:06' },
+            { responsebody: "Dear Redacted\nFOI Response",
+              from: 'Authority',
+              datetime: '2018-01-03 12:05' },
+            { responsebody: "Dear Redacted\nAutomated acknowledgement.",
+              from: 'Authority',
+              datetime: '2018-01-02 11:04' }
+          ]
+        } }
+    end
+  end
+end

--- a/spec/models/published_request_spec.rb
+++ b/spec/models/published_request_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe PublishedRequest, type: :model do
       published_request.reload
     end
 
+    it 'creates a cache of the reference' do
+      expect(published_request.reference).to eq('FOI-1')
+    end
+
     it 'creates a cache of the keywords' do
       expect(published_request.keywords).to eq('Business, business rates')
     end

--- a/spec/models/published_request_spec.rb
+++ b/spec/models/published_request_spec.rb
@@ -3,4 +3,38 @@
 require 'rails_helper'
 
 RSpec.describe PublishedRequest, type: :model do
+  describe '#save' do
+    let(:published_request) { build(:published_request) }
+
+    before do
+      published_request.save!
+      published_request.reload
+    end
+
+    it 'creates a cache of the keywords' do
+      expect(published_request.keywords).to eq('Business, business rates')
+    end
+
+    it 'creates a cache of the url' do
+      url = 'http://foi.infreemation.co.uk/redirect/hackney?id=1'
+      expect(published_request.url).to eq(url)
+    end
+
+    it 'creates a cache of the subject as title' do
+      expect(published_request.title).to eq('Business Rates')
+    end
+
+    it 'constructs a cache of the summary' do
+      # Munge all responses in to one field for searching
+      expected = <<-TEXT.strip_heredoc.chomp
+      Initial FOI Request
+      Dear Redacted
+      Automated acknowledgement.
+      Dear Redacted
+      FOI Response
+      Thank you for your help
+      TEXT
+      expect(published_request.summary).to eq(expected)
+    end
+  end
 end

--- a/spec/models/published_request_spec.rb
+++ b/spec/models/published_request_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublishedRequest, type: :model do
+end

--- a/spec/models/published_request_spec.rb
+++ b/spec/models/published_request_spec.rb
@@ -3,6 +3,39 @@
 require 'rails_helper'
 
 RSpec.describe PublishedRequest, type: :model do
+  describe '.create_or_update_from_api!' do
+    subject { described_class.create_or_update_from_api!(attributes) }
+
+    context 'when a record with the ref does not exist' do
+      let(:attributes) { attributes_for(:published_request)[:payload] }
+
+      it 'persists the record' do
+        expect { subject }.to change { described_class.count }.by(1)
+      end
+    end
+
+    context 'when a record with the ref exists and attributes have changed' do
+      let(:attributes) { attributes_for(:published_request)[:payload] }
+
+      let!(:published_request) do
+        old_attrs =
+          attributes.merge(dateclosed: '1918-04-22', keywords: 'old')
+
+        create(:published_request, payload: old_attrs)
+      end
+
+      it 'does not create a new record' do
+        expect { subject }.not_to(change { described_class.count })
+      end
+
+      it 'updates the payload' do
+        subject
+        expect(published_request.reload.payload['keywords']).
+          to eq('Business, business rates')
+      end
+    end
+  end
+
   describe '#save' do
     let(:published_request) { build(:published_request) }
 


### PR DESCRIPTION
## Relevant issue(s)

Work on #25

## What does this do?

  * Adds a model (`PublishedRequest`) for caching disclosure log records from the API

## What isn't covered?

  * Service that handles importing the disclosure log from the API
  * Doesn't incorporate in to `FoiSuggestion` – I'm not confident in getting that done quickly
  
## Why was this needed?

To store data to later incorporate in to `FoiSuggestion`

## Implementation notes

  * `PublishedRequest` is a duck type of `CuratedLink` for the purposes of `FoiSuggestion`

## Notes to reviewer

  * This replaces #126 
  * Decided to ditch checking if the `dateclosed` attribute has changed to detimine if the record needs updating and instead just update regardless