### PR TITLE
[#139] export PublishedRequest analytics

### DIFF
--- a/app/controllers/admin/exports_controller.rb
+++ b/app/controllers/admin/exports_controller.rb
@@ -7,7 +7,7 @@ module Admin
   class ExportsController < AdminController
     def show
       respond_to do |format|
-        format.csv  { render csv: CuratedLink.all }
+        format.csv  { render csv: Resource.all }
       end
     end
   end

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
+##
 # Resources added by staff that appear in the Suggestions to users.
+#
 class CuratedLink < ApplicationRecord
   has_many :foi_suggestions, as: :resource, dependent: :destroy
 

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -18,10 +18,6 @@ class CuratedLink < ApplicationRecord
     %i[id title url keywords shown click_rate answer_rate created_at updated_at]
   end
 
-  def as_csv
-    csv_columns.map { |column| public_send(column) }
-  end
-
   def soft_destroy
     update(destroyed_at: Time.zone.now)
   end

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -14,7 +14,7 @@ class CuratedLink < ApplicationRecord
     @statistics ||= OpenStruct.new(foi_suggestions.statistics)
   end
 
-  def csv_columns
+  def self.csv_columns
     %i[id title url keywords shown click_rate answer_rate created_at updated_at]
   end
 

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -10,16 +10,6 @@ class CuratedLink < ApplicationRecord
 
   scope :active, -> { where(destroyed_at: nil) }
 
-  delegate :shown, :click_rate, :answer_rate, to: :statistics
-
-  def statistics
-    @statistics ||= OpenStruct.new(foi_suggestions.statistics)
-  end
-
-  def self.csv_columns
-    %i[id title url keywords shown click_rate answer_rate created_at updated_at]
-  end
-
   def soft_destroy
     update(destroyed_at: Time.zone.now)
   end

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -4,6 +4,8 @@
 # A cache of published FOI requests and responses from the disclosure log.
 #
 class PublishedRequest < ApplicationRecord
+  has_many :foi_suggestions, as: :resource, dependent: :destroy
+
   before_save :update_cached_columns
 
   def self.create_or_update_from_api!(attrs)

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -10,9 +10,13 @@ class Resource < ApplicationRecord
   delegate :shown, :click_rate, :answer_rate, to: :statistics
 
   def self.csv_columns
-    %i[id title url keywords
+    %i[id type title url keywords
        shown click_rate answer_rate
        created_at updated_at]
+  end
+
+  def type
+    resource_type.titleize
   end
 
   private

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -7,4 +7,17 @@ class Resource < ApplicationRecord
   belongs_to :resource, polymorphic: true
 
   delegate :foi_suggestions, :id, :created_at, :updated_at, to: :resource
+  delegate :shown, :click_rate, :answer_rate, to: :statistics
+
+  def self.csv_columns
+    %i[id title url keywords
+       shown click_rate answer_rate
+       created_at updated_at]
+  end
+
+  private
+
+  def statistics
+    @statistics ||= OpenStruct.new(foi_suggestions.statistics)
+  end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -5,4 +5,6 @@
 #
 class Resource < ApplicationRecord
   belongs_to :resource, polymorphic: true
+
+  delegate :foi_suggestions, :id, :created_at, :updated_at, to: :resource
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
+##
+# Union of CuratedLink and PublishedRequest powered by a Postgres view
+#
 class Resource < ApplicationRecord
+  belongs_to :resource, polymorphic: true
 end

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -12,13 +12,15 @@ class CSVExporter
 
   def initialize(objects, _options = nil)
     @objects = objects
+    return if objects&.empty?
+
     raise Error, "#{klass} doesn't respond to `csv_columns`" unless
       klass.respond_to?(:csv_columns)
   end
 
   def data
     CSV.generate do |csv|
-      csv << headers if headers
+      csv << headers unless headers.empty?
       objects.each { |object| csv << convert_to_csv(object) }
     end
   end
@@ -30,7 +32,7 @@ class CSVExporter
   end
 
   def headers
-    @headers ||= klass.csv_columns
+    @headers ||= klass&.csv_columns || []
   end
 
   def convert_to_csv(object)

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+##
+# Class to help with exporting data as CSV
+#
+class CSVExporter
+  attr_reader :objects
+
+  Error = Class.new(ArgumentError)
+
+  def initialize(objects, _options = nil)
+    @objects = objects
+    raise Error, "#{klass} doesn't respond to `csv_columns`" unless
+      klass.respond_to?(:csv_columns)
+  end
+
+  def data
+    CSV.generate do |csv|
+      csv << headers if headers
+      objects.each { |object| csv << convert_to_csv(object) }
+    end
+  end
+
+  private
+
+  def klass
+    @klass ||= objects&.first&.class
+  end
+
+  def headers
+    @headers ||= klass.csv_columns
+  end
+
+  def convert_to_csv(object)
+    object.class.csv_columns.map do |column|
+      map_value(object.public_send(column))
+    end
+  end
+
+  def map_value(value)
+    case value
+    when Time then value.to_s(:db)
+    else value
+    end
+  end
+end

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -13,7 +13,13 @@ require 'csv'
 
 ActionController::Renderers.add :csv do |objects, _options|
   def convert_to_csv(object)
-    object.csv_columns.map { |column| object.public_send(column) }
+    object.csv_columns.map do |column|
+      value = object.public_send(column)
+      case value
+      when Time then value.to_s(:db)
+      else value
+      end
+    end
   end
 
   csv_string = CSV.generate do |csv|

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -12,10 +12,14 @@
 require 'csv'
 
 ActionController::Renderers.add :csv do |objects, _options|
+  def convert_to_csv(object)
+    object.csv_columns.map { |column| object.public_send(column) }
+  end
+
   csv_string = CSV.generate do |csv|
     headers = objects.first&.csv_columns
     csv << headers if headers
-    objects.each { |object| csv << object.as_csv }
+    objects.each { |object| csv << convert_to_csv(object) }
   end
 
   send_data csv_string, type: Mime[:csv], filename: 'export.csv'

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -9,29 +9,7 @@
 #   )
 # end
 
-require 'csv'
-
-ActionController::Renderers.add :csv do |objects, _options|
-  klass = objects.first&.class
-  unless klass.respond_to?(:csv_columns)
-    raise StandardError, "#{klass} class doesn't respond to `csv_columns`"
-  end
-
-  def convert_to_csv(object)
-    object.class.csv_columns.map do |column|
-      value = object.public_send(column)
-      case value
-      when Time then value.to_s(:db)
-      else value
-      end
-    end
-  end
-
-  csv_string = CSV.generate do |csv|
-    headers = klass.csv_columns
-    csv << headers if headers
-    objects.each { |object| csv << convert_to_csv(object) }
-  end
-
-  send_data csv_string, type: Mime[:csv], filename: 'export.csv'
+ActionController::Renderers.add :csv do |objects, options|
+  export = CSVExporter.new(objects, options)
+  send_data export.data, type: Mime[:csv], filename: 'export.csv'
 end

--- a/spec/controllers/admin/exports_controller_spec.rb
+++ b/spec/controllers/admin/exports_controller_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Admin::ExportsController, type: :controller do
 
       expect(lines).to include([
         link.id, link.title, link.url, link.keywords, link.shown,
-        link.click_rate, link.answer_rate, link.created_at, link.updated_at
+        link.click_rate, link.answer_rate,
+        link.created_at.to_s(:db), link.updated_at.to_s(:db)
       ].join(','))
     end
   end

--- a/spec/controllers/admin/exports_controller_spec.rb
+++ b/spec/controllers/admin/exports_controller_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe Admin::ExportsController, type: :controller do
 
     it 'should have CSV headers' do
       expect(lines).to include(
-        'id,title,url,keywords,shown,' \
+        'id,type,title,url,keywords,shown,' \
         'click_rate,answer_rate,created_at,updated_at'
       )
     end
 
     it 'should have CSV data' do
       expect(lines).to include([
-        resource.id,
+        resource.id, resource.type,
         resource.title, resource.url, resource.keywords,
         resource.shown, resource.click_rate, resource.answer_rate,
         resource.created_at.to_s(:db), resource.updated_at.to_s(:db)

--- a/spec/controllers/admin/exports_controller_spec.rb
+++ b/spec/controllers/admin/exports_controller_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe Admin::ExportsController, type: :controller do
       get :show, params: { format: 'csv' }, session: session
     end
 
-    let!(:suggestion) { create(:foi_suggestion) }
+    let!(:resource) do
+      link = create(:curated_link_with_suggestions)
+      Resource.find_by(resource_id: link.id, resource_type: 'CuratedLink')
+    end
+    let(:lines) { response.body.split("\n") }
 
     it 'should return a CSV' do
       is_expected.to have_http_status(200)
@@ -24,8 +28,6 @@ RSpec.describe Admin::ExportsController, type: :controller do
     end
 
     it 'should have CSV headers' do
-      lines = response.body.split("\n")
-
       expect(lines).to include(
         'id,title,url,keywords,shown,' \
         'click_rate,answer_rate,created_at,updated_at'
@@ -33,13 +35,11 @@ RSpec.describe Admin::ExportsController, type: :controller do
     end
 
     it 'should have CSV data' do
-      link = suggestion.resource
-      lines = response.body.split("\n")
-
       expect(lines).to include([
-        link.id, link.title, link.url, link.keywords, link.shown,
-        link.click_rate, link.answer_rate,
-        link.created_at.to_s(:db), link.updated_at.to_s(:db)
+        resource.id,
+        resource.title, resource.url, resource.keywords,
+        resource.shown, resource.click_rate, resource.answer_rate,
+        resource.created_at.to_s(:db), resource.updated_at.to_s(:db)
       ].join(','))
     end
   end

--- a/spec/factories/published_requests.rb
+++ b/spec/factories/published_requests.rb
@@ -35,5 +35,11 @@ FactoryBot.define do
           ]
         } }
     end
+
+    factory :published_request_with_suggestions do
+      after(:create) do |published_request, _evaluator|
+        create_list(:foi_suggestion, 3, resource: published_request)
+      end
+    end
   end
 end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :resource do
+    association :resource, factory: :curated_link, strategy: :build
+  end
+end

--- a/spec/models/curated_link_spec.rb
+++ b/spec/models/curated_link_spec.rb
@@ -31,36 +31,6 @@ RSpec.describe CuratedLink, type: :model do
     end
   end
 
-  describe '.csv_columns' do
-    it 'returns an array' do
-      expect(described_class.csv_columns).to be_a Array
-    end
-  end
-
-  describe 'statistics delegate methods' do
-    before do
-      expect(curated_link).to(
-        receive_message_chain(:foi_suggestions, :statistics).
-        and_return(shown: 3, click_rate: 0.66, answer_rate: 0.33)
-      )
-    end
-
-    describe '#shown' do
-      subject { curated_link.shown }
-      it { is_expected.to eq 3 }
-    end
-
-    describe '#click_rate' do
-      subject { curated_link.click_rate }
-      it { is_expected.to eq 0.66 }
-    end
-
-    describe '#answer_rate' do
-      subject { curated_link.answer_rate }
-      it { is_expected.to eq 0.33 }
-    end
-  end
-
   describe 'scopes' do
     let!(:active) { create(:curated_link, destroyed_at: nil) }
     let!(:destroyed) { create(:curated_link, destroyed_at: Time.zone.now) }

--- a/spec/models/curated_link_spec.rb
+++ b/spec/models/curated_link_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe CuratedLink, type: :model do
     end
   end
 
+  describe '.csv_columns' do
+    it 'returns an array' do
+      expect(described_class.csv_columns).to be_a Array
+    end
+  end
+
   describe 'statistics delegate methods' do
     before do
       expect(curated_link).to(

--- a/spec/models/published_request_spec.rb
+++ b/spec/models/published_request_spec.rb
@@ -3,6 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe PublishedRequest, type: :model do
+  let(:published_request) { build_stubbed(:published_request) }
+
+  describe 'associations' do
+    it 'has many FOI suggestions' do
+      expect(published_request.foi_suggestions.new).to be_a FoiSuggestion
+    end
+
+    it 'removes FOI suggestions on destroy' do
+      published_request = create(:published_request_with_suggestions)
+      expect { published_request.destroy }.to change(FoiSuggestion, :count).
+        from(3).to(0)
+    end
+  end
+
   describe '.create_or_update_from_api!' do
     subject { described_class.create_or_update_from_api!(attributes) }
 

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -12,4 +12,29 @@ RSpec.describe Resource, type: :model do
       expect(resource.resource_type).to eq 'CuratedLink'
     end
   end
+
+  describe 'resource delegate methods' do
+    before do
+      resource.resource = CuratedLink.new(
+        id: 3,
+        created_at: Time.new(2018, 1, 1, 0, 0).utc,
+        updated_at: Time.new(2018, 1, 1, 0, 1).utc
+      )
+    end
+
+    describe '#id' do
+      subject { resource.id }
+      it { is_expected.to eq 3 }
+    end
+
+    describe '#created_at' do
+      subject { resource.created_at }
+      it { is_expected.to eq Time.new(2018, 1, 1, 0, 0).utc }
+    end
+
+    describe '#updated_at' do
+      subject { resource.updated_at }
+      it { is_expected.to eq Time.new(2018, 1, 1, 0, 1).utc }
+    end
+  end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -67,4 +67,13 @@ RSpec.describe Resource, type: :model do
       it { is_expected.to eq 0.33 }
     end
   end
+
+  describe '#type' do
+    subject { resource.type }
+
+    it 'titleise the resource_type' do
+      resource.resource_type = 'FooBar_baz'
+      is_expected.to eq 'Foo Bar Baz'
+    end
+  end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Resource, type: :model do
     end
   end
 
+  describe '.csv_columns' do
+    it 'returns an array' do
+      expect(described_class.csv_columns).to be_a Array
+    end
+  end
+
   describe 'resource delegate methods' do
     before do
       resource.resource = CuratedLink.new(
@@ -35,6 +41,30 @@ RSpec.describe Resource, type: :model do
     describe '#updated_at' do
       subject { resource.updated_at }
       it { is_expected.to eq Time.new(2018, 1, 1, 0, 1).utc }
+    end
+  end
+
+  describe 'statistics delegate methods' do
+    before do
+      expect(resource).to(
+        receive_message_chain(:foi_suggestions, :statistics).
+        and_return(shown: 3, click_rate: 0.66, answer_rate: 0.33)
+      )
+    end
+
+    describe '#shown' do
+      subject { resource.shown }
+      it { is_expected.to eq 3 }
+    end
+
+    describe '#click_rate' do
+      subject { resource.click_rate }
+      it { is_expected.to eq 0.66 }
+    end
+
+    describe '#answer_rate' do
+      subject { resource.answer_rate }
+      it { is_expected.to eq 0.33 }
     end
   end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resource, type: :model do
+  let(:resource) { build_stubbed(:resource) }
+
+  describe 'associations' do
+    it 'belongs to a polymorphic resource' do
+      expect(resource.resource).to be_a CuratedLink
+      expect(resource.resource_id).to be_a Numeric
+      expect(resource.resource_type).to eq 'CuratedLink'
+    end
+  end
+end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Resource, type: :model do
     before do
       resource.resource = CuratedLink.new(
         id: 3,
-        created_at: Time.new(2018, 1, 1, 0, 0).utc,
-        updated_at: Time.new(2018, 1, 1, 0, 1).utc
+        created_at: Time.utc(2018, 1, 1, 0, 0),
+        updated_at: Time.utc(2018, 1, 1, 0, 1)
       )
     end
 
@@ -35,12 +35,12 @@ RSpec.describe Resource, type: :model do
 
     describe '#created_at' do
       subject { resource.created_at }
-      it { is_expected.to eq Time.new(2018, 1, 1, 0, 0).utc }
+      it { is_expected.to eq Time.utc(2018, 1, 1, 0, 0) }
     end
 
     describe '#updated_at' do
       subject { resource.updated_at }
-      it { is_expected.to eq Time.new(2018, 1, 1, 0, 1).utc }
+      it { is_expected.to eq Time.utc(2018, 1, 1, 0, 1) }
     end
   end
 

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CSVExporter, type: :service do
+  Mock = Struct.new(:name, :time)
+  class MockEvent < Mock
+    def self.csv_columns
+      %i[name time]
+    end
+  end
+
+  let(:objects) { [MockEvent.new('event', Time.utc(2018, 6, 20, 15, 30))] }
+  subject(:export) { described_class.new(objects) }
+
+  describe 'initialisation' do
+    it 'assigns objects' do
+      expect(export.objects).to eq objects
+    end
+
+    it 'requires class which response to csv_columns' do
+      expect { export }.to_not raise_error
+      expect { described_class.new(['foo']) }.to raise_error(CSVExporter::Error)
+    end
+  end
+
+  describe '#data' do
+    subject(:data) { export.data }
+    let(:lines) { data.split("\n") }
+
+    it 'generates valid CSV string' do
+      expect { CSV.parse(data).inspect }.to_not raise_error
+    end
+
+    it 'includes CSV headers' do
+      expect(lines.first).to eq 'name,time'
+    end
+
+    it 'maps Times to DB format' do
+      expect(lines.last).to eq 'event,2018-06-20 15:30:00'
+    end
+  end
+end

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe CSVExporter, type: :service do
       expect { export }.to_not raise_error
       expect { described_class.new(['foo']) }.to raise_error(CSVExporter::Error)
     end
+
+    it 'can handle no objects without raising an error' do
+      expect { described_class.new([]) }.to_not raise_error
+    end
   end
 
   describe '#data' do
@@ -38,6 +42,11 @@ RSpec.describe CSVExporter, type: :service do
 
     it 'maps Times to DB format' do
       expect(lines.last).to eq 'event,2018-06-20 15:30:00'
+    end
+
+    context 'without an objects' do
+      let(:objects) { [] }
+      it { is_expected.to eq '' }
     end
   end
 end

--- a/spec/services/disclosure_log_spec.rb
+++ b/spec/services/disclosure_log_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DisclosureLog, type: :service do
   end
 
   describe 'initialisation' do
-    before { travel_to Time.new(2018, 6, 18, 11, 30).utc }
+    before { travel_to Time.utc(2018, 6, 18, 11, 30) }
 
     it 'accepts a start_date' do
       subject = described_class.new(start_date: Date.new(2018, 2, 1))

--- a/spec/workers/import_disclosure_log_worker_spec.rb
+++ b/spec/workers/import_disclosure_log_worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ImportDisclosureLogWorker, type: :worker do
   let(:duration) { nil }
   subject(:perform) { described_class.perform_async(duration) }
 
-  before { travel_to Time.new(2018, 6, 18, 11, 30).utc }
+  before { travel_to Time.utc(2018, 6, 18, 11, 30) }
   around { |example| Sidekiq::Testing.inline!(&example) }
 
   let(:log) { double(:disclosure_log) }


### PR DESCRIPTION
## Relevant issue(s)

Fixes #139

## What does this do?

  * Adds `PubishedRequest` analytics statistics to the suggestion export CSV
  * Adds a `type` column to the CSV to distingish between `CuratedLink` and `PubishedRequest` records

## Why was this needed?

To get statistics on how well past published requests are performing.
