### PR TITLE
[#149] Format imported suggestion summaries

### DIFF
--- a/app/helpers/suggestions_helper.rb
+++ b/app/helpers/suggestions_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+##
+# Helper for the public view of FOI Request Suggestions
+#
+module SuggestionsHelper
+  def format_summary(summary)
+    cleaned = strip_tags(CGI.unescapeHTML(summary.gsub('\r\n', "\r\n").squish))
+    truncate(cleaned, length: 175, omission: '…', separator: ' ')
+  end
+end

--- a/app/views/foi/suggestions/_suggestion.html.erb
+++ b/app/views/foi/suggestions/_suggestion.html.erb
@@ -1,5 +1,11 @@
 <%= link_to link_to_suggestion(suggestion), class: 'foi-suggestion js-suggestion-link text', target: '_blank' do %>
-  <h3 class="heading-medium js-suggestion-title"><%= suggestion.title %></h3>
-  <p class="summary js-suggestion-summary"><%= truncate suggestion.summary, length: 175 %></p>
+  <h3 class="heading-medium js-suggestion-title">
+    <%= suggestion.title %>
+  </h3>
+
+  <p class="summary js-suggestion-summary">
+    <%= format_summary(suggestion.summary) %>
+  </p>
+
   <p><span class="link-fake">Open in a new window</span></p>
 <% end %>

--- a/spec/helpers/suggestions_helper_spec.rb
+++ b/spec/helpers/suggestions_helper_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SuggestionsHelper, type: :helper do
+  include SuggestionsHelper
+
+  describe '#format_summary' do
+    it 'truncates text to 175 chars' do
+      input = 'x' * 200
+      expect(format_summary(input).length).to eq(175)
+    end
+
+    it 'truncates with an elipses' do
+      input = 'x' * 200
+      expect(format_summary(input).last).to eq('…')
+    end
+
+    it 'separates at a natural break' do
+      # Otherwise you get 'word SPACE ...'
+      input = 'x ' * 200
+      expect(format_summary(input)).not_to match(/\s…\z/)
+    end
+
+    it 'replaces carriage returns with a space' do
+      input = "Some\r\ntext\r\nfrom\r\nDOS.\r\n"
+      expect(format_summary(input)).to eq('Some text from DOS.')
+    end
+
+    it 'replaces false carriage returns with a space' do
+      input = 'Some\r\ntext\r\nfrom\r\nDOS.\r\n'
+      expect(format_summary(input)).to eq('Some text from DOS.')
+    end
+
+    it 'strips tags from encoded HTML' do
+      input = '&lt;p&gt;Hello&lt;/p&gt;'
+      expect(format_summary(input)).to eq('Hello')
+    end
+
+    it 'strips tags from decoded HTML' do
+      input = '<p>Hello</p>'
+      expect(format_summary(input)).to eq('Hello')
+    end
+
+    it 'strips HTML attributes' do
+      input = '&lt;p style=&quot;\color:rgb(1, 1, 1)&quot;\&gt;Blah&lt;/p&gt;'
+      expect(format_summary(input)).to eq('Blah')
+    end
+  end
+end


### PR DESCRIPTION
We receive published requests in escaped and encoded JSON.

We need to clean this up before display, otherwise users see escaped
characters.

I've stripped all the HTML out so that it doesn't mess up our interface
– we just want the raw text.

Required for https://github.com/mysociety/foi-for-councils/issues/149.

**Before:**

![screen shot 2018-06-29 at 14 55 56](https://user-images.githubusercontent.com/282788/42098933-2326fc86-7bb4-11e8-8020-fcc08f1197ad.png)

**After:**

![screen shot 2018-06-29 at 15 48 22](https://user-images.githubusercontent.com/282788/42098947-282e63a4-7bb4-11e8-856c-231b6aabbc80.png)

