### PR TITLE
[#157] Clean PublishedRequest#summary when caching

### DIFF
--- a/app/helpers/suggestions_helper.rb
+++ b/app/helpers/suggestions_helper.rb
@@ -5,7 +5,6 @@
 #
 module SuggestionsHelper
   def format_summary(summary)
-    cleaned = strip_tags(CGI.unescapeHTML(summary.gsub('\r\n', "\r\n").squish))
-    truncate(cleaned, length: 175, omission: '…', separator: ' ')
+    truncate(summary, length: 175, omission: '…', separator: ' ')
   end
 end

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -45,7 +45,7 @@ class PublishedRequest < ApplicationRecord
     text = payload['requestbody']
     text += "\n"
     text += responses.reverse.join("\n")
-    self.summary = text
+    self.summary = Summary.new(text).clean
   end
 
   def responses

--- a/app/models/summary.rb
+++ b/app/models/summary.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+##
+# Value object for PublishedRequest and CuratedLink summary attributes
+#
+class Summary < SimpleDelegator
+  include ActionView::Helpers::SanitizeHelper
+
+  def clean
+    strip_tags(CGI.unescapeHTML(gsub('\r\n', "\r\n").squish))
+  end
+end

--- a/spec/helpers/suggestions_helper_spec.rb
+++ b/spec/helpers/suggestions_helper_spec.rb
@@ -21,30 +21,5 @@ RSpec.describe SuggestionsHelper, type: :helper do
       input = 'x ' * 200
       expect(format_summary(input)).not_to match(/\s…\z/)
     end
-
-    it 'replaces carriage returns with a space' do
-      input = "Some\r\ntext\r\nfrom\r\nDOS.\r\n"
-      expect(format_summary(input)).to eq('Some text from DOS.')
-    end
-
-    it 'replaces false carriage returns with a space' do
-      input = 'Some\r\ntext\r\nfrom\r\nDOS.\r\n'
-      expect(format_summary(input)).to eq('Some text from DOS.')
-    end
-
-    it 'strips tags from encoded HTML' do
-      input = '&lt;p&gt;Hello&lt;/p&gt;'
-      expect(format_summary(input)).to eq('Hello')
-    end
-
-    it 'strips tags from decoded HTML' do
-      input = '<p>Hello</p>'
-      expect(format_summary(input)).to eq('Hello')
-    end
-
-    it 'strips HTML attributes' do
-      input = '&lt;p style=&quot;\color:rgb(1, 1, 1)&quot;\&gt;Blah&lt;/p&gt;'
-      expect(format_summary(input)).to eq('Blah')
-    end
   end
 end

--- a/spec/models/published_request_spec.rb
+++ b/spec/models/published_request_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe PublishedRequest, type: :model do
 
     it 'constructs a cache of the summary' do
       # Munge all responses in to one field for searching
-      expected = <<-TEXT.strip_heredoc.chomp
+      expected = <<-TEXT.strip_heredoc.chomp.squish
       Initial FOI Request
       Dear Redacted
       Automated acknowledgement.

--- a/spec/models/summary_spec.rb
+++ b/spec/models/summary_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Summary, type: :model do
+  describe '#clean' do
+    it 'replaces carriage returns with a space' do
+      input = "Some\r\ntext\r\nfrom\r\nDOS.\r\n"
+      expect(described_class.new(input).clean).to eq('Some text from DOS.')
+    end
+
+    it 'replaces false carriage returns with a space' do
+      input = 'Some\r\ntext\r\nfrom\r\nDOS.\r\n'
+      expect(described_class.new(input).clean).to eq('Some text from DOS.')
+    end
+
+    it 'strips tags from encoded HTML' do
+      input = '&lt;p&gt;Hello&lt;/p&gt;'
+      expect(described_class.new(input).clean).to eq('Hello')
+    end
+
+    it 'strips tags from decoded HTML' do
+      input = '<p>Hello</p>'
+      expect(described_class.new(input).clean).to eq('Hello')
+    end
+
+    it 'strips HTML attributes' do
+      input = '&lt;p style=&quot;\color:rgb(1, 1, 1)&quot;\&gt;Blah&lt;/p&gt;'
+      expect(described_class.new(input).clean).to eq('Blah')
+    end
+  end
+end


### PR DESCRIPTION
We use the `summary` attribute when looking for suggestions to present
to the user, so cleaning it should help with search ranking.

Also means less processing at view render time, as now the helper is
just truncating, so a small performance boost too.

Fixes #157