### PR TITLE
[#200] tsquery boolean operators

### DIFF
--- a/app/services/generate_foi_suggestion.rb
+++ b/app/services/generate_foi_suggestion.rb
@@ -80,7 +80,9 @@ class GenerateFoiSuggestion
   def self.keywords_query
     <<~SQL
       SELECT array_to_string(ARRAY_AGG(
-        '(''' || regexp_replace(keyword, '\s+', ''' & ''', 'g') || ''')'
+        regexp_replace(
+          '(''' || regexp_replace(keyword, '\s+', ''' & ''', 'g') || ''')'
+        , '''''\s*!', '!')
       ), ' | ')
       FROM (#{keywords}) AS T(keyword)
     SQL

--- a/app/services/generate_foi_suggestion.rb
+++ b/app/services/generate_foi_suggestion.rb
@@ -80,7 +80,7 @@ class GenerateFoiSuggestion
   def self.keywords_query
     <<~SQL
       SELECT array_to_string(ARRAY_AGG(
-        '(' || regexp_replace(keyword, '\s+', ' & ', 'g') || ')'
+        '(''' || regexp_replace(keyword, '\s+', ''' & ''', 'g') || ''')'
       ), ' | ')
       FROM (#{keywords}) AS T(keyword)
     SQL
@@ -90,7 +90,9 @@ class GenerateFoiSuggestion
   # Get a unique list of all comma separated keywords from current resources
   def self.keywords
     <<~SQL
-      SELECT DISTINCT UNNEST(regexp_split_to_array(keywords, ',\s*'))
+      SELECT DISTINCT UNNEST(
+        regexp_split_to_array(replace(keywords, '''', ''''''), ',\s*')
+      )
       FROM resources _r
       WHERE (
         _r.resource_id = resources.resource_id AND

--- a/app/services/generate_foi_suggestion.rb
+++ b/app/services/generate_foi_suggestion.rb
@@ -81,7 +81,14 @@ class GenerateFoiSuggestion
     <<~SQL
       SELECT array_to_string(ARRAY_AGG(
         regexp_replace(
-          '(''' || regexp_replace(keyword, '\s+', ''' & ''', 'g') || ''')'
+          '(''' ||
+          CASE
+          WHEN false) THEN
+            NULL
+          ELSE
+            regexp_replace(keyword, '\s+', ''' & ''', 'g')
+          END
+          || ''')'
         , '''''\s*!', '!')
       ), ' | ')
       FROM (#{keywords}) AS T(keyword)

--- a/app/services/generate_foi_suggestion.rb
+++ b/app/services/generate_foi_suggestion.rb
@@ -83,8 +83,8 @@ class GenerateFoiSuggestion
         regexp_replace(
           '(''' ||
           CASE
-          WHEN false) THEN
-            NULL
+          WHEN (keyword ~ '[&|!]') THEN
+            regexp_replace(keyword, '(\s*[&|!]\s+)', ''' \\1 ''', 'g')
           ELSE
             regexp_replace(keyword, '\s+', ''' & ''', 'g')
           END

--- a/spec/services/generate_foi_suggestion_spec.rb
+++ b/spec/services/generate_foi_suggestion_spec.rb
@@ -118,6 +118,46 @@ RSpec.describe GenerateFoiSuggestion, type: :service do
       end
     end
 
+    context 'resource with AND boolean operator in keyword' do
+      let!(:link) { create(:curated_link, keywords: 'teacher & support staff') }
+
+      it 'returns matches to keywords' do
+        s1 = suggest('teacher')
+        s2 = suggest('teacher & support staff')
+        s3 = suggest('support staff')
+
+        expect(s1.resource).to eq link
+        expect(s2.resource).to eq link
+        expect(s3.resource).to eq link
+      end
+    end
+
+    context 'resource with OR boolean operator in keyword' do
+      let!(:link) { create(:curated_link, keywords: 'foo | bar') }
+
+      it 'returns matches to keywords' do
+        s1 = suggest('foo')
+        expect(s1.resource).to eq link
+
+        s2 = suggest('bar')
+        expect(s2.resource).to eq link
+      end
+    end
+
+    context 'resource with NOT boolean operator in keyword' do
+      let!(:link) { create(:curated_link, keywords: '! baz') }
+
+      it 'returns matches to keywords' do
+        # This spec is here to check the query isn't broken.
+        # We're expecting the resource to match the link due to how ts_highlight
+        # works. It will highlights any matching part of the input string,
+        # including those for NOT operations. This means we can't support the
+        # NOT operation with our current implementation.
+        s1 = suggest('baz')
+        expect(s1.resource).to eq link
+      end
+    end
+
     context 'resource without keywords' do
       before { create(:curated_link, keywords: '') }
 


### PR DESCRIPTION
Fixes #200 

If keywords contain boolean operators characters then it could result in invalid tsquery. 

Given the keywords:
`a's & bs'`, `aye | hello`, `yes & ! no`, `foo&bar baz`, `two words`, `this & that thing`, `! nah1`, `!nah2`

These changes will turn the tsquery from:
`(a's & & & bs') | (aye & | & hello) |  (yes & & & ! & no) | (foo&bar & baz) | (two & words) | (this & & & that & thing) | (! & nah1) | (!nah2)`
which is invalid

To:
`('a''s'  &  'bs''') | ('aye'  |  'hello') | ('yes'  &  !  'no') | ('foo&bar baz') | ('two' & 'words') | ('this'  &  'that thing') | (!  'nah1') | ('!nah2')`
which is valid