### PR TITLE
Update rbenv and ruby-build on provision

### DIFF
--- a/script/provision-vagrant.sh
+++ b/script/provision-vagrant.sh
@@ -12,6 +12,16 @@ if [ ! -d "$HOME/.rbenv" ]; then
     ~/.rbenv/plugins/ruby-build
   echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
   echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+else
+  echo 'Updating rbenv'
+  pushd ~/.rbenv > /dev/null
+  git pull
+  popd > /dev/null
+
+  echo 'Updating ruby-build'
+  pushd ~/.rbenv/plugins/ruby-build > /dev/null
+  git pull
+  popd > /dev/null
 fi
 
 export PATH="$HOME/.rbenv/bin:$PATH"


### PR DESCRIPTION
9a94734 introduced a Ruby version bump, but this version wasn't defined
in the version of ruby-build installed at the last provision.

This caused `vagrant provision` to fail as the expected ruby version
wasn't available.

This commit updates `rbenv` and `ruby-build` on `vagrant provision` so
that it always has up-to-date Ruby definitions.