### PR TITLE
[#207] Run checkDeliveryStatus on document ready

### DIFF
--- a/app/assets/javascripts/application/async-delivery-status.js
+++ b/app/assets/javascripts/application/async-delivery-status.js
@@ -42,6 +42,6 @@ var checkDeliveryStatus = function () {
   runTimer()
 }
 
-document.addEventListener('turbolinks:load', function () {
+$(document).ready(function () {
   $('.js-async-delivery-status').each(checkDeliveryStatus)
 })


### PR DESCRIPTION
We use `async: true` in our `javascript_include_tag`, which seems to
prevent us firing the `checkDeliveryStatus` event.

> Looks like this is because we fire the initial turbolinks:load event
> in response to DOMContentLoaded, which will likely already have fired
> by the time Turbolinks is loaded asynchronously.
>
> – https://github.com/turbolinks/turbolinks/issues/28#issuecomment-189898761

Waiting for document ready appears to fix the problem.

Fixes https://github.com/mysociety/foi-for-councils/issues/207