### PR TITLE
Add site-specific exception notification subject

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -20,8 +20,10 @@ ExceptionNotification.configure do |config|
   recipients = ENV['EXCEPTION_NOTIFICATIONS_TO']
   recipients = recipients.split(',').map(&:chomp) if recipients
 
+  site_name = ENV.fetch('VHOST', 'foi-for-councils')
+
   config.add_notifier :email,
-                      email_prefix: '[foi-for-councils][ERROR] ',
+                      email_prefix: "[#{site_name}][ERROR] ",
                       sender_address: ENV['EXCEPTION_NOTIFICATIONS_FROM'],
                       exception_recipients: recipients
 end

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -23,7 +23,7 @@ ExceptionNotification.configure do |config|
   site_name = ENV.fetch('VHOST', 'foi-for-councils')
 
   config.add_notifier :email,
-                      email_prefix: "[#{site_name}][ERROR] ",
+                      email_prefix: "[#{site_name}] [ERROR] ",
                       sender_address: ENV['EXCEPTION_NOTIFICATIONS_FROM'],
                       exception_recipients: recipients
 end


### PR DESCRIPTION
This makes it easier to figure out which install has gone wrong.

## Notes to Reviewer

Tested by applying this:

```diff
diff --git a/app/controllers/foi/requests_controller.rb b/app/controllers/foi/requests_controller.rb
index 658683d..754f203 100644
--- a/app/controllers/foi/requests_controller.rb
+++ b/app/controllers/foi/requests_controller.rb
@@ -10,7 +10,9 @@ module Foi
     before_action :new_foi_request, only: %i[new create]
     before_action :find_foi_request, only: %i[edit update]
 
-    def index; end
+    def index
+      raise 'Foo'
+    end
 
     def new; end
```

Test default case:

```
RAILS_ENV=production bin/rails s -b 0.0.0.0

GET http://192.168.33.143:3000/foi

grep '(RuntimeError) "Foo"' log/production.log
Subject: [foi-for-councils][ERROR] requests#index (RuntimeError) "Foo"
```

Test specific case:

```
VHOST="192.168.33.143:3000" RAILS_ENV=production bin/rails s -b 0.0.0.0

GET http://192.168.33.143:3000/foi

grep '(RuntimeError) "Foo"' log/production.log
Subject: [192.168.33.143:3000][ERROR] requests#index (RuntimeError) "Foo"
```