### PR TITLE
Remove custom bundler versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ before_script:
   - cp config/database.yml-travis config/database.yml
 before_install:
   - "echo '--colour' > ~/.rspec"
-  - gem install bundler
-  - gem update --system
 install: bundle install
 notifications:
   email: false


### PR DESCRIPTION
aba8b203bceecc4e5e411536e89b5411af6f410c updated bundler to fix a Travis
CI issue.

    $ gem install bundler
    $ gem update --system
    Updating rubygems-update
    Fetching: rubygems-update-3.1.1.gem (100%)
    Successfully installed rubygems-update-3.1.1
    Installing RubyGems 3.1.1
      Successfully built RubyGem
      Name: bundler
      Version: 2.1.0
      File: bundler-2.1.0.gem
    bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-2.5.3/bin/bundle
    Overwrite the executable? [yN]
    No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
    Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
    The build has been terminated