### PR TITLE
Fix disclosure log URL

### DIFF
--- a/app/views/foi/requests/index.html.erb
+++ b/app/views/foi/requests/index.html.erb
@@ -11,7 +11,7 @@
   </strong>
 
   All FOI and EIR responses we send out will be published in the
-  <%= link_to 'disclosure log', 'https://hackney.gov.uk/foi-disclosure-log' %> on
+  <%= link_to 'disclosure log', 'https://foi.infreemation.co.uk/hackney/' %> on
   our website.
 </p>
 


### PR DESCRIPTION
The hackney.gov.uk URL no longer works. They link directly to the
Infreemation URL from their FOI info page [1] so we'll do the same here
for now.

Fixes https://github.com/mysociety/foi-for-councils/issues/287

[1] https://hackney.gov.uk/foi-request