### PR TITLE
[#295] Fix exception on edit contact form

### DIFF
--- a/app/controllers/foi/contacts_controller.rb
+++ b/app/controllers/foi/contacts_controller.rb
@@ -10,6 +10,7 @@ module Foi
 
     before_action :find_foi_request
     before_action :redirect_if_exisiting_contact, only: %i[new create]
+    before_action :redirect_if_no_contact, only: %i[edit update]
     before_action :new_contact, only: %i[new create]
     before_action :find_contact, only: %i[edit update]
 
@@ -43,6 +44,12 @@ module Foi
 
     def new_contact
       @contact = @foi_request.build_contact
+    end
+
+    def redirect_if_no_contact
+      return if @foi_request.contact
+
+      redirect_to new_foi_request_contact_path
     end
 
     def find_contact

--- a/spec/controllers/foi/contacts_controller_spec.rb
+++ b/spec/controllers/foi/contacts_controller_spec.rb
@@ -88,13 +88,41 @@ RSpec.describe Foi::ContactsController, type: :controller do
   describe 'GET #edit' do
     subject { get :edit, session: { request_id: '1' } }
 
-    it 'returns http success' do
-      is_expected.to have_http_status(200)
+    context 'no contact' do
+      subject { get :edit, session: { request_id: '1' } }
+      before { allow(foi_request).to receive(:contact).and_return(nil) }
+
+      it 'redirects to new contact' do
+        is_expected.to redirect_to(new_foi_request_contact_path)
+      end
+    end
+
+    context 'existing contact' do
+      it 'returns http success' do
+        is_expected.to have_http_status(200)
+      end
     end
   end
 
   describe 'PUT #update' do
     before { allow(foi_request).to receive(:contact).and_return(contact) }
+
+    context 'no contact' do
+      subject do
+        put :update, params: { contact: valid_params },
+                     session: { request_id: '1' }
+      end
+      before { allow(foi_request).to receive(:contact).and_return(nil) }
+
+      it 'does not receive attributes' do
+        expect(contact).to_not receive(:update)
+        subject
+      end
+
+      it 'redirects to new contact' do
+        is_expected.to redirect_to(new_foi_request_contact_path)
+      end
+    end
 
     context 'valid parameters' do
       subject do


### PR DESCRIPTION
Fixes #295 

When edit contact form route is loaded before any contact details have
been added an exception is raise:
```
  An ActionView::Template::Error occurred in contacts#edit:

  First argument in form cannot contain nil or be empty
  app/views/foi/contacts/_form.html.erb:10
```

Added a before action callback to check and redirect to the new contact
form instead.