### PR TITLE
Relax ruby/setup-ruby version specifier

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,7 +41,7 @@ jobs:
           ${{ runner.os }}-gems-
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.29.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5.8
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,22 +33,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5.8
-
-    - name: Install gems
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
 
     - name: Setup database
       env:


### PR DESCRIPTION
I can't see a reason why we wouldn't want to always use the latest for
simply installing Ruby.

Fixes CI failing due to deprecated commands [1].

[1] https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/