### PR TITLE
Update target Ruby version to 2.6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - 'vendor/**/*'
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 
 Metrics/BlockLength:
   Exclude:

--- a/app/services/queue_submission.rb
+++ b/app/services/queue_submission.rb
@@ -9,11 +9,9 @@ class QueueSubmission < SimpleDelegator
     update(state: Submission::QUEUED)
 
     ActiveRecord::Base.transaction do
-      begin
-        update(job_id: DeliverSubmissionWorker.perform_async(id))
-      rescue Redis::BaseConnectionError
-        raise ActiveRecord::Rollback
-      end
+      update(job_id: DeliverSubmissionWorker.perform_async(id))
+    rescue Redis::BaseConnectionError
+      raise ActiveRecord::Rollback
     end || update(state: Submission::UNQUEUED)
   end
 end

--- a/bin/spring
+++ b/bin/spring
@@ -9,12 +9,10 @@ if !defined?(Spring) && [nil, 'development', 'test'].include?(ENV['RAILS_ENV'])
   Bundler.locked_gems&.specs&.find do |spec|
     spec.name == 'spring'
   end&.tap do |spring|
-    begin
-      Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-      gem 'spring', spring.version
-      require 'spring/binstub'
-    rescue Gem::LoadError
-      # Ignore when Spring is not installed.
-    end
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  rescue Gem::LoadError
+    # Ignore when Spring is not installed.
   end
 end


### PR DESCRIPTION
This means we can use do/end blocks with rescue.

See: https://bugs.ruby-lang.org/issues/12906