### PR TITLE
[#387] Annotate models with schema information

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'annotate', '~> 3.1.0'
   # Access an interactive console on exception pages or by calling 'console'
   # anywhere in the code.
   gem 'listen', '>= 3.0.5', '< 3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     bindex (0.8.1)
     bootsnap (1.7.2)
@@ -334,6 +337,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate (~> 3.1.0)
   bootsnap (>= 1.1.0)
   byebug
   exception_notification

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -2,6 +2,16 @@
 
 require 'mysociety/validate'
 
+# == Schema Information
+#
+# Table name: contacts
+#
+#  id         :bigint           not null, primary key
+#  email      :string           not null
+#  full_name  :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+
 ##
 # This model represents a contact details of an user.
 #

--- a/app/models/curated_link.rb
+++ b/app/models/curated_link.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: curated_links
+#
+#  id           :bigint           not null, primary key
+#  destroyed_at :datetime
+#  keywords     :string
+#  summary      :text
+#  title        :string           not null
+#  url          :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+
 ##
 # Resources added by staff that appear in the Suggestions to users.
 #

--- a/app/models/foi_request.rb
+++ b/app/models/foi_request.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: foi_requests
+#
+#  id            :bigint           not null, primary key
+#  body          :text             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  contact_id    :bigint
+#  submission_id :bigint
+
 ##
 # This model represents an FOI request.
 #

--- a/app/models/foi_suggestion.rb
+++ b/app/models/foi_suggestion.rb
@@ -1,7 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: foi_suggestions
+#
+#  id              :bigint           not null, primary key
+#  clicks          :integer          default(0), not null
+#  relevance       :decimal(7, 6)
+#  request_matches :string
+#  resource_type   :string
+#  submissions     :integer          default(0), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  foi_request_id  :bigint
+#  resource_id     :bigint
+
 ##
-# This model represents an suggested answer to an FOI requests
+# This model represents an suggested answer to an FOI requests.
 #
 class FoiSuggestion < ApplicationRecord
   belongs_to :foi_request, optional: true

--- a/app/models/performance.rb
+++ b/app/models/performance.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: performances
+#
+#  id         :bigint           not null, primary key
+#  percentage :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+
 ##
-# This model represents the performance percentage of the organisation
+# This model represents the performance percentage of the organisation.
 #
 class Performance < ApplicationRecord
   validates :percentage, presence: true, numericality: {

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: published_requests
+#
+#  id             :bigint           not null, primary key
+#  api_created_at :datetime
+#  keywords       :string
+#  payload        :jsonb
+#  published_at   :datetime
+#  reference      :string
+#  summary        :text
+#  title          :string
+#  url            :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+
 ##
 # A cache of published FOI requests and responses from the disclosure log.
 #

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: resources
+#
+#  keywords      :string
+#  resource_type :text
+#  summary       :text
+#  title         :string
+#  url           :string
+#  resource_id   :bigint
+
 ##
-# Union of CuratedLink and PublishedRequest powered by a Postgres view
+# Union of CuratedLink and PublishedRequest powered by a Postgres view.
 #
 class Resource < ApplicationRecord
   belongs_to :resource, polymorphic: true

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: submissions
+#
+#  id         :bigint           not null, primary key
+#  reference  :string
+#  state      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  job_id     :string
+
 ##
 # This model represents the state of a submission to external case management
 # software.

--- a/app/models/summary.rb
+++ b/app/models/summary.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ##
-# Value object for PublishedRequest and CuratedLink summary attributes
+# Value object for PublishedRequest and CuratedLink summary attributes.
 #
 class Summary < SimpleDelegator
   include ActionView::Helpers::SanitizeHelper

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :bigint           not null, primary key
+#  email      :string
+#  name       :string
+#  provider   :string
+#  uid        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+
 ##
-# This model represents a user which has authenticate via OmniAuth
+# This model represents a user which has authenticate via OmniAuth.
 #
 class User < ApplicationRecord
   def self.find_or_create_with_omniauth(auth_hash)

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -93,6 +93,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     bindex (0.8.1)
     bootsnap (1.7.2)
@@ -340,6 +343,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate (~> 3.1.0)
   bootsnap (>= 1.1.0)
   byebug
   exception_notification

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+
+  ANNOTATE_DEFAULTS = {
+    'active_admin' => 'false',
+    'additional_file_patterns' => [],
+    'routes' => 'false',
+    'models' => 'true',
+    'position_in_routes' => 'before',
+    'position_in_class' => 'before',
+    'position_in_test' => 'before',
+    'position_in_fixture' => 'before',
+    'position_in_factory' => 'before',
+    'position_in_serializer' => 'before',
+    'show_foreign_keys' => 'false',
+    'show_complete_foreign_keys' => 'false',
+    'show_indexes' => 'false',
+    'simple_indexes' => 'false',
+    'model_dir' => 'app/models',
+    'root_dir' => '',
+    'include_version' => 'false',
+    'require' => '',
+    'exclude_tests' => 'true',
+    'exclude_fixtures' => 'true',
+    'exclude_factories' => 'true',
+    'exclude_serializers' => 'false',
+    'exclude_scaffolds' => 'true',
+    'exclude_controllers' => 'true',
+    'exclude_helpers' => 'true',
+    'exclude_sti_subclasses' => 'false',
+    'ignore_model_sub_dir' => 'false',
+    'ignore_columns' => nil,
+    'ignore_routes' => nil,
+    'ignore_unknown_models' => 'false',
+    'hide_limit_column_types' => 'integer,bigint,boolean',
+    'hide_default_column_types' => 'json,jsonb,hstore',
+    'skip_on_db_migrate' => 'false',
+    'format_bare' => 'true',
+    'format_rdoc' => 'false',
+    'format_yard' => 'false',
+    'format_markdown' => 'false',
+    'sort' => 'false',
+    'force' => 'false',
+    'frozen' => 'false',
+    'classified_sort' => 'true',
+    'trace' => 'false',
+    'wrapper_open' => nil,
+    'wrapper_close' => nil,
+    'with_comment' => 'true'
+  }.freeze
+
+  task set_annotation_options: :environment do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(ANNOTATE_DEFAULTS)
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
Annotate models with schema information

Installs and configures annotate to annotate models on `db:migrate` in
development mode only.

I never remember the schema, and while you can look in `db/schema.rb`
it's always easier to see just the specific table information alongside
the model that you're currently working on.

Mostly uses the defaults from `rails g:annotate:install`, but sets
`show_foreign_keys` and `show_indexes` to `false` since if you're
thinking about those you probably _do_ want to look in `db/schema.rb`.
Also excludes specs and factories as you don't tend to need a reminder
of the schema quite as frequently there.

Fixes https://github.com/mysociety/foi-for-councils/issues/387.