### PR TITLE
[#383] Extract case management backend

### DIFF
--- a/app/models/case_management/infreemation.rb
+++ b/app/models/case_management/infreemation.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CaseManagement
+  # Implementation of a CaseManagement for the Infreemation Case Management
+  # System.
+  class Infreemation
+    def initialize(client: nil)
+      @client = client || ::Infreemation::Request
+    end
+
+    def submit_foi_request!(name:, email:, body:)
+      request = client.create!(
+        rt: 'create',
+        type: 'FOI',
+        contacttype: 'email',
+        requester: name,
+        contact: email,
+        body: body
+      )
+
+      SubmittedRequest.new(request)
+    end
+
+    protected
+
+    attr_reader :client
+  end
+end

--- a/app/models/case_management/infreemation.rb
+++ b/app/models/case_management/infreemation.rb
@@ -21,6 +21,18 @@ module CaseManagement
       SubmittedRequest.new(request)
     end
 
+    def published_requests(query_params)
+      client_params = {
+        rt: 'published',
+        startdate: query_params[:start_date],
+        enddate: query_params[:end_date]
+      }
+
+      client.
+        where(client_params).
+        map { |request| PublishedRequest.new(request) }
+    end
+
     protected
 
     attr_reader :client

--- a/app/models/case_management/infreemation/published_request.rb
+++ b/app/models/case_management/infreemation/published_request.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module CaseManagement
+  class Infreemation
+    # Adapter for the published requests feed from the Infreemation Case
+    # Management System.
+    class PublishedRequest
+      def initialize(request)
+        @request = request
+      end
+
+      def reference
+        attributes[:ref]
+      end
+
+      def title
+        attributes[:title]
+      end
+
+      def url
+        attributes[:url]
+      end
+
+      def summary
+        text = attributes[:requestbody]
+        text += "\n"
+        text += responses.reverse.join("\n")
+        Summary.new(text).clean
+      end
+
+      def keywords
+        attributes[:keywords]
+      end
+
+      def published_at
+        date = attributes[:datepublished]
+        Date.parse(date) if date.present?
+      end
+
+      def api_created_at
+        date = attributes[:datecreated]
+        Date.parse(date)
+      end
+
+      def publishable?
+        attributes[:datepublished].present?
+      end
+
+      def payload
+        attributes
+      end
+
+      # Hash for ApplicationRecord#assign_attributes
+      def to_h
+        { reference: reference,
+          title: title,
+          url: url,
+          summary: summary,
+          keywords: keywords,
+          published_at: published_at,
+          api_created_at: api_created_at,
+          publishable: publishable?,
+          payload: payload }
+      end
+
+      def ==(other)
+        other.request == request
+      end
+
+      protected
+
+      attr_reader :request
+
+      private
+
+      def responses
+        attributes[:history].fetch(:response, []).pluck(:responsebody)
+      end
+
+      def attributes
+        request.attributes
+      end
+    end
+  end
+end

--- a/app/models/case_management/infreemation/submitted_request.rb
+++ b/app/models/case_management/infreemation/submitted_request.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module CaseManagement
+  class Infreemation
+    # Adapter for the response value after submitting an FOI request to the
+    # Infreemation CaseManagement.
+    class SubmittedRequest
+      def initialize(request)
+        @request = request
+      end
+
+      def reference
+        attributes[:ref]
+      end
+
+      protected
+
+      attr_reader :request
+
+      private
+
+      def attributes
+        request.attributes
+      end
+    end
+  end
+end

--- a/app/services/deliver_submission.rb
+++ b/app/services/deliver_submission.rb
@@ -7,24 +7,25 @@
 class DeliverSubmission < SimpleDelegator
   delegate :contact, to: :foi_request
 
-  def call
-    request = Infreemation::Request.create!(attributes)
-    update(
-      state: Submission::DELIVERED,
-      reference: request.attributes[:ref]
-    )
+  def initialize(obj, case_management: nil)
+    super(obj)
+    @case_management = case_management || CaseManagement::Infreemation.new
   end
+
+  def call
+    submitted_request = case_management.submit_foi_request!(**attributes)
+    update(state: Submission::DELIVERED, reference: submitted_request.reference)
+  end
+
+  protected
+
+  attr_reader :case_management
 
   private
 
   def attributes
-    {
-      rt: 'create',
-      type: 'FOI',
-      requester: contact.full_name,
-      contact: contact.email,
-      contacttype: 'email',
-      body: foi_request.body
-    }
+    { name: contact.full_name,
+      email: contact.email,
+      body: foi_request.body }
   end
 end

--- a/app/services/disclosure_log.rb
+++ b/app/services/disclosure_log.rb
@@ -6,9 +6,10 @@
 class DisclosureLog
   attr_reader :start_date, :end_date
 
-  def initialize(start_date: nil, end_date: nil)
+  def initialize(start_date: nil, end_date: nil, case_management: nil)
     @start_date = start_date || Time.zone.today.beginning_of_year
     @end_date = end_date || Time.zone.today
+    @case_management = case_management || CaseManagement::Infreemation.new
   end
 
   def import!
@@ -21,14 +22,18 @@ class DisclosureLog
   end
 
   def import
-    Infreemation::Request.where(query_params).map do |request|
-      PublishedRequest.create_update_or_destroy_from_api!(request.attributes)
+    case_management.published_requests(query_params).map do |request|
+      PublishedRequest.create_update_or_destroy_from_api!(request)
     end
   end
+
+  protected
+
+  attr_reader :case_management
 
   private
 
   def query_params
-    { rt: 'published', startdate: start_date, enddate: end_date }
+    { start_date: start_date, end_date: end_date }
   end
 end

--- a/spec/models/case_management/infreemation/published_request_spec.rb
+++ b/spec/models/case_management/infreemation/published_request_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CaseManagement::Infreemation::PublishedRequest, type: :model do
+  let(:request) { described_class.new(api_response) }
+
+  let(:api_response) do
+    Infreemation::Request.new(attributes)
+  end
+
+  let(:attributes) do
+    {
+      ref: 'FOI-001',
+      title: 'An FOI Request',
+      url: 'https://foi.example.com/FOI-001',
+      requestbody: 'Initial FOI Request',
+      history: {
+        response: [
+          { responsebody: "Dear Redacted\nFOI Response" },
+          { responsebody: "Dear Redacted\nAutomated acknowledgement." }
+        ]
+      },
+      keywords: 'bins, waste, missed bins',
+      datepublished: '2018-01-05',
+      datecreated: '2018-01-01'
+    }
+  end
+
+  describe '#reference' do
+    subject { request.reference }
+    it { is_expected.to eq('FOI-001') }
+  end
+
+  describe '#title' do
+    subject { request.title }
+    it { is_expected.to eq('An FOI Request') }
+  end
+
+  describe '#url' do
+    subject { request.url }
+    it { is_expected.to eq('https://foi.example.com/FOI-001') }
+  end
+
+  describe '#summary' do
+    subject { request.summary }
+    it { is_expected.to eq(<<-TEXT.strip_heredoc.chomp.squish) }
+    Initial FOI Request
+    Dear Redacted
+    Automated acknowledgement.
+    Dear Redacted
+    FOI Response
+    TEXT
+  end
+
+  describe '#keywords' do
+    subject { request.keywords }
+    it { is_expected.to eq('bins, waste, missed bins') }
+  end
+
+  describe '#published_at' do
+    subject { request.published_at }
+
+    context 'when there is a datepublished' do
+      it { is_expected.to eq(Date.parse('2018-01-05')) }
+    end
+
+    context 'when datepublished is empty' do
+      before { attributes[:datepublished] = nil }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#publishable?' do
+    subject { request.publishable? }
+
+    context 'when there is a datepublished' do
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when datepublished is blank' do
+      before { attributes[:datepublished] = '' }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when datepublished is empty' do
+      before { attributes[:datepublished] = nil }
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe '#api_created_at' do
+    subject { request.api_created_at }
+    it { is_expected.to eq(Date.parse('2018-01-01')) }
+  end
+
+  describe '#payload' do
+    subject { request.payload }
+    it { is_expected.to eq(attributes) }
+  end
+
+  describe '#to_h' do
+    subject { request.to_h }
+
+    let(:summary) do
+      <<-TEXT.strip_heredoc.chomp.squish
+      Initial FOI Request
+      Dear Redacted
+      Automated acknowledgement.
+      Dear Redacted
+      FOI Response
+      TEXT
+    end
+
+    it do
+      is_expected.to eq(
+        reference: 'FOI-001',
+        title: 'An FOI Request',
+        url: 'https://foi.example.com/FOI-001',
+        summary: summary,
+        keywords: 'bins, waste, missed bins',
+        published_at: Date.parse('2018-01-05'),
+        api_created_at: Date.parse('2018-01-01'),
+        publishable: true,
+        payload: attributes
+      )
+    end
+  end
+
+  describe '#==' do
+    subject { request == other }
+
+    context 'when they encapsulate the same request' do
+      let(:other) { described_class.new(api_response) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the encapsulated request is different' do
+      let(:other) { described_class.new(double) }
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/models/case_management/infreemation/submitted_request_spec.rb
+++ b/spec/models/case_management/infreemation/submitted_request_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CaseManagement::Infreemation::SubmittedRequest, type: :model do
+  describe '#reference' do
+    subject { request.reference }
+
+    let(:request) { described_class.new(api_response) }
+
+    let(:api_response) do
+      Infreemation::Request.new(
+        rt: 'create',
+        type: 'FOI',
+        contacttype: 'email',
+        requester: 'Alice Brown',
+        contact: 'alice@example.com',
+        body: 'An FOI request',
+        status: 'OK',
+        ref: 'FOI-001',
+        error: ''
+      )
+    end
+
+    it { is_expected.to eq('FOI-001') }
+  end
+end

--- a/spec/models/case_management/infreemation_spec.rb
+++ b/spec/models/case_management/infreemation_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CaseManagement::Infreemation, type: :model do
+  describe '#submit_foi_request!' do
+    subject do
+      case_management.submit_foi_request!(name: request_attrs[:name],
+                                          email: request_attrs[:email],
+                                          body: request_attrs[:body])
+    end
+
+    let(:case_management) { described_class.new(client: client) }
+    let(:client) { double(create!: Infreemation::Request.new(ref: 'FOI-001')) }
+
+    let(:request_attrs) do
+      { name: 'John Doe',
+        email: 'john@example.com',
+        body: 'Some information' }
+    end
+
+    it 'submits the request with the required parameters' do
+      parameters = { rt: 'create',
+                     type: 'FOI',
+                     contacttype: 'email',
+                     requester: request_attrs[:name],
+                     contact: request_attrs[:email],
+                     body: request_attrs[:body] }
+
+      expect(client).to receive(:create!).with(parameters)
+      subject
+    end
+
+    it 'returns the result as a SubmittedRequest' do
+      expect(subject).to be_a(described_class::SubmittedRequest)
+      expect(subject.reference).to eq('FOI-001')
+    end
+  end
+end

--- a/spec/models/case_management/infreemation_spec.rb
+++ b/spec/models/case_management/infreemation_spec.rb
@@ -36,4 +36,33 @@ RSpec.describe CaseManagement::Infreemation, type: :model do
       expect(subject.reference).to eq('FOI-001')
     end
   end
+
+  describe '#published_requests' do
+    subject { case_management.published_requests(query_params) }
+
+    let(:case_management) { described_class.new(client: client) }
+    let(:client) { double(where: published_requests) }
+    let(:published_requests) { [double, double] }
+
+    let(:query_params) { { start_date: start_date, end_date: end_date } }
+    let(:start_date) { Time.zone.today.beginning_of_year }
+    let(:end_date) { Time.zone.today }
+
+    it 'queries the API with the required parameters' do
+      parameters = { rt: 'published',
+                     startdate: start_date,
+                     enddate: end_date }
+
+      expect(client).to receive(:where).with(parameters)
+      subject
+    end
+
+    it 'returns a collection of results as PublishedRequests' do
+      expected = published_requests.map do |request|
+        described_class::PublishedRequest.new(request)
+      end
+
+      expect(subject).to match_array(expected)
+    end
+  end
 end


### PR DESCRIPTION
Extracts submissions of requests and importing the disclosure log as published requests to a Case Management backend in preparation for implementing a different Case Management Backend.

Currently retains `CaseManagement::Infreemation` as the default backend. Will need to implement a way of setting the current backend, but that can be done when we implement iCasework.

Fixes #383 