### PR TITLE
[#405] Add source to published requests

### DIFF
--- a/app/models/case_management/icasework.rb
+++ b/app/models/case_management/icasework.rb
@@ -15,6 +15,10 @@ module CaseManagement
       @client = client || ::Icasework::Case
     end
 
+    def name
+      self.class.name
+    end
+
     def submit_foi_request!(name:, email:, body:)
       request = client.create(
         'Type' => 'InformationRequest',

--- a/app/models/case_management/infreemation.rb
+++ b/app/models/case_management/infreemation.rb
@@ -16,6 +16,10 @@ module CaseManagement
       @client = client || ::Infreemation::Request
     end
 
+    def name
+      self.class.name
+    end
+
     def submit_foi_request!(name:, email:, body:)
       request = client.create!(
         rt: 'create',

--- a/app/models/case_management/infreemation.rb
+++ b/app/models/case_management/infreemation.rb
@@ -38,7 +38,7 @@ module CaseManagement
 
       client.
         where(client_params).
-        map { |request| PublishedRequest.new(request) }
+        map { |request| self.class::PublishedRequest.new(request) }
     end
 
     protected

--- a/app/models/case_management/infreemation/published_request.rb
+++ b/app/models/case_management/infreemation/published_request.rb
@@ -60,6 +60,7 @@ module CaseManagement
           published_at: published_at,
           api_created_at: api_created_at,
           publishable: publishable?,
+          case_management: self.class.module_parent.name,
           payload: payload }
       end
 

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -4,17 +4,19 @@
 #
 # Table name: published_requests
 #
-#  id             :bigint           not null, primary key
-#  api_created_at :datetime
-#  keywords       :string
-#  payload        :jsonb
-#  published_at   :datetime
-#  reference      :string
-#  summary        :text
-#  title          :string
-#  url            :string
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id              :bigint           not null, primary key
+#  api_created_at  :datetime
+#  case_management :string
+#  keywords        :string
+#  payload         :jsonb
+#  published_at    :datetime
+#  reference       :string
+#  summary         :text
+#  title           :string
+#  url             :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
 
 ##
 # A cache of published FOI requests and responses from the disclosure log.
@@ -27,6 +29,8 @@ class PublishedRequest < ApplicationRecord
   # they're publishable. If they are, then we update our cache; if not, we must
   # destroy it from our cache.
   attr_accessor :publishable
+
+  scope :source, ->(source) { where(case_management: source.name) }
 
   def self.create_update_or_destroy_from_api!(request)
     record = find_or_initialize_by(reference: request.reference)

--- a/app/services/disclosure_log.rb
+++ b/app/services/disclosure_log.rb
@@ -18,7 +18,11 @@ class DisclosureLog
                    pluck(:reference)
     imported_refs = import.pluck(:reference)
     expired_refs = current_refs - imported_refs
-    PublishedRequest.where(reference: expired_refs).destroy_all
+
+    PublishedRequest.
+      source(case_management).
+      where(reference: expired_refs).
+      destroy_all
   end
 
   def import

--- a/db/migrate/20210316124123_add_case_management_to_published_requests.rb
+++ b/db/migrate/20210316124123_add_case_management_to_published_requests.rb
@@ -1,0 +1,5 @@
+class AddCaseManagementToPublishedRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :published_requests, :case_management, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_03_085317) do
+ActiveRecord::Schema.define(version: 2021_03_16_124123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2020_08_03_085317) do
     t.string "reference"
     t.datetime "published_at"
     t.datetime "api_created_at"
+    t.string "case_management"
   end
 
   create_table "submissions", force: :cascade do |t|

--- a/spec/factories/published_requests.rb
+++ b/spec/factories/published_requests.rb
@@ -24,6 +24,8 @@ FactoryBot.define do
       { ref: 'FOI-001' }
     end
 
+    case_management { 'CaseManagement::Fake' }
+
     factory :published_request_with_suggestions do
       after(:create) do |published_request, _evaluator|
         create_list(:foi_suggestion, 3, resource: published_request)

--- a/spec/models/case_management/icasework_spec.rb
+++ b/spec/models/case_management/icasework_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe CaseManagement::Icasework, type: :model do
     it { is_expected.to eq(params) }
   end
 
+  describe '#name' do
+    subject { described_class.new.name }
+    it { is_expected.to eq('CaseManagement::Icasework') }
+  end
+
   describe '#submit_foi_request!' do
     subject do
       case_management.submit_foi_request!(name: request_attrs[:name],

--- a/spec/models/case_management/infreemation/published_request_spec.rb
+++ b/spec/models/case_management/infreemation/published_request_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe CaseManagement::Infreemation::PublishedRequest, type: :model do
         published_at: Date.parse('2018-01-05'),
         api_created_at: Date.parse('2018-01-01'),
         publishable: true,
+        case_management: 'CaseManagement::Infreemation',
         payload: attributes
       )
     end

--- a/spec/models/case_management/infreemation_spec.rb
+++ b/spec/models/case_management/infreemation_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe CaseManagement::Infreemation, type: :model do
     it { is_expected.to eq(params) }
   end
 
+  describe '#name' do
+    subject { described_class.new.name }
+    it { is_expected.to eq('CaseManagement::Infreemation') }
+  end
+
   describe '#submit_foi_request!' do
     subject do
       case_management.submit_foi_request!(name: request_attrs[:name],

--- a/spec/models/published_request_spec.rb
+++ b/spec/models/published_request_spec.rb
@@ -17,6 +17,24 @@ RSpec.describe PublishedRequest, type: :model do
     end
   end
 
+  describe '.source' do
+    subject { described_class.source(case_management) }
+
+    let!(:fake) do
+      FactoryBot.create(:published_request,
+                        case_management: 'CaseManagement::Fake')
+    end
+
+    let!(:other) do
+      FactoryBot.create(:published_request,
+                        case_management: 'CaseManagement::Other')
+    end
+
+    let(:case_management) { double(name: 'CaseManagement::Fake') }
+
+    it { is_expected.to match_array([fake]) }
+  end
+
   describe '.create_update_or_destroy_from_api!' do
     subject { described_class.create_update_or_destroy_from_api!(request) }
 


### PR DESCRIPTION
Part of #385 
Fixes #405

Store the `CaseManagement` that was used to cache a `PublishedRequest` so that we can scope the `DisclosureLog` importer to only that `CaseManagement`.

Note that the Infreemation sandbox doesn't include a `url` attribute in the payload, but live does.