### PR TITLE
[#385] Delegate to CaseManagement for url generation

### DIFF
--- a/app/models/case_management.rb
+++ b/app/models/case_management.rb
@@ -4,8 +4,14 @@
 # Load the current CaseManagement client for the current environment.
 #
 module CaseManagement
+  def self.constantize(name)
+    name = name.dup
+    name.prepend("#{self.name}::") unless name.starts_with?(self.name)
+    name.constantize
+  end
+
   def self.current
-    @current ||= "CaseManagement::#{config[:adapter]}".constantize.new
+    @current ||= constantize(config[:adapter]).new
   end
 
   def self.current=(case_management)
@@ -14,11 +20,7 @@ module CaseManagement
 
   def self.config
     @config ||= Rails.application.config_for(:case_management)
-
-    "CaseManagement::#{@config[:adapter]}".
-      constantize.
-      configure!(@config[:client_params])
-
+    constantize(@config[:adapter]).configure!(@config[:client_params])
     @config
   end
 end

--- a/app/models/case_management.rb
+++ b/app/models/case_management.rb
@@ -18,6 +18,11 @@ module CaseManagement
     @current = case_management
   end
 
+  def self.generate_url(published_request)
+    constantize(published_request.case_management).new.
+      generate_url(published_request)
+  end
+
   def self.config
     @config ||= Rails.application.config_for(:case_management)
     constantize(@config[:adapter]).configure!(@config[:client_params])

--- a/app/models/case_management/infreemation.rb
+++ b/app/models/case_management/infreemation.rb
@@ -45,6 +45,10 @@ module CaseManagement
         map { |request| self.class::PublishedRequest.new(request) }
     end
 
+    def generate_url(published_request)
+      published_request.url
+    end
+
     protected
 
     attr_reader :client

--- a/app/models/published_request.rb
+++ b/app/models/published_request.rb
@@ -39,6 +39,10 @@ class PublishedRequest < ApplicationRecord
     record
   end
 
+  def url
+    self[:url] || CaseManagement.generate_url(self)
+  end
+
   def save_or_destroy!
     if publishable?
       save!

--- a/spec/models/case_management/infreemation_spec.rb
+++ b/spec/models/case_management/infreemation_spec.rb
@@ -85,4 +85,11 @@ RSpec.describe CaseManagement::Infreemation, type: :model do
       expect(subject).to match_array(expected)
     end
   end
+
+  describe '#generate_url' do
+    subject { case_management.generate_url(published_request) }
+    let(:case_management) { described_class.new }
+    let(:published_request) { double(url: 'https://example.com') }
+    it { is_expected.to eq('https://example.com') }
+  end
 end

--- a/spec/models/case_management_spec.rb
+++ b/spec/models/case_management_spec.rb
@@ -56,6 +56,26 @@ RSpec.describe CaseManagement, type: :model do
     end
   end
 
+  describe '.generate_url' do
+    subject { described_class.generate_url(published_request) }
+
+    let(:published_request) do
+      double(case_management: 'CaseManagement::Infreemation')
+    end
+
+    let(:fake_case_management) { double(generate_url: 'https://example.org') }
+
+    before do
+      expect(CaseManagement::Infreemation).
+        to receive(:new).and_return(fake_case_management)
+
+      expect(fake_case_management).
+        to receive(:generate_url).with(published_request)
+    end
+
+    it { is_expected.to eq('https://example.org') }
+  end
+
   describe '.config' do
     subject { described_class.config }
 

--- a/spec/models/case_management_spec.rb
+++ b/spec/models/case_management_spec.rb
@@ -6,6 +6,20 @@ RSpec.describe CaseManagement, type: :model do
   before { described_class.current = nil }
   after { described_class.current = nil }
 
+  describe '.constantize' do
+    subject { described_class.constantize(name) }
+
+    context 'when the name is correctly namespaced' do
+      let(:name) { 'CaseManagement::Infreemation' }
+      it { is_expected.to eq(CaseManagement::Infreemation) }
+    end
+
+    context 'when only the class name is given' do
+      let(:name) { 'Infreemation' }
+      it { is_expected.to eq(CaseManagement::Infreemation) }
+    end
+  end
+
   describe '.current' do
     subject { described_class.current }
 

--- a/spec/models/published_request_spec.rb
+++ b/spec/models/published_request_spec.rb
@@ -67,6 +67,28 @@ RSpec.describe PublishedRequest, type: :model do
     end
   end
 
+  describe '#url' do
+    subject { published_request.url }
+    let(:published_request) { build(:published_request, url: url) }
+
+    context 'when the url is set' do
+      let(:url) { 'https://example.com' }
+      it { is_expected.to eq('https://example.com') }
+    end
+
+    context 'when the url is nil' do
+      let(:url) { nil }
+
+      before do
+        expect(CaseManagement).
+          to receive(:generate_url).with(published_request).
+          and_return('https://example.com')
+      end
+
+      it { is_expected.to eq('https://example.com') }
+    end
+  end
+
   describe '#save_or_destroy!' do
     let(:published_request) { build(:published_request) }
 


### PR DESCRIPTION
If we don't have a URL stored, delegate to the `CaseManagement` to generate it.

NOOP for Infreemation since we always store a URL, but we'll need this for iCasework.