### PR TITLE
[#413] Improve Icasework::PublishedRequest#publish_at

### DIFF
--- a/app/models/case_management/icasework/published_request.rb
+++ b/app/models/case_management/icasework/published_request.rb
@@ -34,9 +34,10 @@ module CaseManagement
         request.classifications.flat_map { |c| [c.group, c.title] }.join(', ')
       end
 
-      # TODO: Check whether there's a better attribute available
       def published_at
-        api_created_at
+        publish_in_the_disclosure_log_date ||
+          case_stage_stage_1_date_completed ||
+          api_created_at
       end
 
       def publishable?
@@ -73,6 +74,19 @@ module CaseManagement
 
       attr_reader :request
 
+      def publish_in_the_disclosure_log_date
+        try_parse_date(
+          request[:case_details_information_request] \
+          [:publish_in_the_disclosure_log_date]
+        )
+      end
+
+      def case_stage_stage_1_date_completed
+        try_parse_date(
+          request[:case_stage_stage].pluck(:date_completed).compact.min
+        )
+      end
+
       def case_details
         request[:case_details]
       end
@@ -87,6 +101,10 @@ module CaseManagement
 
       def documents
         request[:documents]
+      end
+
+      def try_parse_date(date)
+        Date.parse(date) if date
       end
     end
   end

--- a/app/models/case_management/icasework/published_request.rb
+++ b/app/models/case_management/icasework/published_request.rb
@@ -74,6 +74,8 @@ module CaseManagement
 
       attr_reader :request
 
+      private
+
       def publish_in_the_disclosure_log_date
         try_parse_date(
           request[:case_details_information_request] \

--- a/spec/models/case_management/icasework/published_request_spec.rb
+++ b/spec/models/case_management/icasework/published_request_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe CaseManagement::Icasework::PublishedRequest, type: :model do
         reason_information_not_held: 't',
         suitable_for_publication_scheme: 'Yes'
       },
+      case_details_information_request: {
+        publish_in_the_disclosure_log_date: '2021-03-20'
+      },
+      case_stage_stage: [
+        { date_completed: '2021-03-18' },
+        { date_completed: '2021-03-19' }
+      ],
       classifications: [
         { group: 'G1', __content__: 'Bins' },
         { group: 'G2', __content__: 'Waste' },
@@ -72,7 +79,34 @@ RSpec.describe CaseManagement::Icasework::PublishedRequest, type: :model do
 
   describe '#published_at' do
     subject { request.published_at }
-    it { is_expected.to eq(Date.parse('2021-02-15')) }
+
+    context 'when there is a publish_in_the_disclosure_log_date' do
+      it { is_expected.to eq(Date.parse('2021-03-20')) }
+    end
+
+    context 'when there is no publish_in_the_disclosure_log_date' do
+      before do
+        attributes[:case_details_information_request][
+          :publish_in_the_disclosure_log_date] = nil
+      end
+
+      it 'falls back to CaseStageStage1.DateCompleted' do
+        is_expected.to eq(Date.parse('2021-03-18'))
+      end
+    end
+
+    context 'when there is no CaseStageStage1.DateCompleted' do
+      before do
+        attributes[:case_details_information_request][
+          :publish_in_the_disclosure_log_date] = nil
+
+        attributes[:case_stage_stage] = []
+      end
+
+      it 'falls back to the api_created_at' do
+        is_expected.to eq(Date.parse('2021-02-15'))
+      end
+    end
   end
 
   describe '#publishable?' do
@@ -125,7 +159,7 @@ RSpec.describe CaseManagement::Icasework::PublishedRequest, type: :model do
         url: nil,
         summary: summary,
         keywords: 'G1, Bins, G2, Waste, G3, Missed bins',
-        published_at: Date.parse('2021-02-15'),
+        published_at: Date.parse('2021-03-20'),
         api_created_at: Date.parse('2021-02-15'),
         publishable: true,
         case_management: 'CaseManagement::Icasework',


### PR DESCRIPTION
Try to pick the best date for `published_at`.

We _should_ have a `publish_in_the_disclosure_log_date` available, but
if not use `CaseStageStage1.DateCompleted`. Failing that, just use
`api_created_at`.

Fixes https://github.com/mysociety/foi-for-councils/issues/413.