### PR TITLE
[#423] Retrieve documents flagged as self service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'govuk_elements_form_builder'
 gem 'hackney_template', path: 'gems/hackney_template-0.0.2'
 
 # Case management
-gem 'icasework', '0.1.0.pre6'
+gem 'icasework', '0.1.0'
 gem 'infreemation'
 
 # Background workers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    icasework (0.1.0.pre6)
+    icasework (0.1.0)
       activesupport (>= 4.0.0)
       jwt (~> 2.2.0)
       nokogiri (~> 1.0)
@@ -363,7 +363,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.1)
   govuk_elements_form_builder
   hackney_template!
-  icasework (= 0.1.0.pre6)
+  icasework (= 0.1.0)
   infreemation
   jbuilder (~> 2.11)
   listen (>= 3.0.5, < 3.5)

--- a/app/models/case_management/icasework.rb
+++ b/app/models/case_management/icasework.rb
@@ -54,7 +54,9 @@ module CaseManagement
       case_id = published_request.reference
       document_id = responses.first[:id]
 
-      ::Icasework::Document.find(case_id: case_id, document_id: document_id).url
+      ::Icasework::Document.find(
+        case_id: case_id, document_id: document_id, self_service: 'True'
+      ).url
     end
 
     protected

--- a/spec/models/case_management/icasework_spec.rb
+++ b/spec/models/case_management/icasework_spec.rb
@@ -142,8 +142,9 @@ RSpec.describe CaseManagement::Icasework, type: :model do
 
     before do
       expect(Icasework::Document).
-        to receive(:find).with(case_id: '1234', document_id: 'D225851').
-        and_return(double(url: 'https://example.com/doc/D225851'))
+        to receive(:find).with(
+          case_id: '1234', document_id: 'D225851', self_service: 'True'
+        ).and_return(double(url: 'https://example.com/doc/D225851'))
     end
 
     it { is_expected.to eq('https://example.com/doc/D225851') }


### PR DESCRIPTION
Fixes https://github.com/mysociety/foi-for-councils/issues/423

We only even want to deal with documents which have been published on
the disclosure log.

The iCasework API describes this options as:
> Set "True" to return only documents that have been marked as public,
> or that have been published to the self service portal.

