### PR TITLE
[#386] extract contents of documents for summary

### DIFF
--- a/app/models/case_management/icasework/published_request.rb
+++ b/app/models/case_management/icasework/published_request.rb
@@ -25,9 +25,8 @@ module CaseManagement
         nil
       end
 
-      # TODO: Extract contents of documents
       def summary
-        case_attributes[:details]
+        [case_attributes[:details], *pdf_contents].join(' ')
       end
 
       def keywords
@@ -107,8 +106,12 @@ module CaseManagement
         request[:attributes]
       end
 
+      def pdf_contents
+        documents.map(&:pdf_contents).compact
+      end
+
       def documents
-        request[:documents]
+        request.documents
       end
 
       def try_parse_date(date)

--- a/spec/models/case_management/icasework/published_request_spec.rb
+++ b/spec/models/case_management/icasework/published_request_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe CaseManagement::Icasework::PublishedRequest, type: :model do
         { group: 'G3', __content__: 'Missed bins' }
       ],
       documents: [
-        { name: 'Response (all information to be supplied)',
+        { id: 'D1234',
+          name: 'Response (all information to be supplied)',
           type: 'applicaion/pdf',
           __content__: 'https://example.com/?ref=D225851&access_token=FOO' }
       ]
@@ -67,8 +68,16 @@ RSpec.describe CaseManagement::Icasework::PublishedRequest, type: :model do
 
   describe '#summary' do
     subject { request.summary }
+
+    before do
+      expect(request).
+        to receive(:documents).
+        and_return([double(pdf_contents: 'PDF')])
+    end
+
     it { is_expected.to eq(<<-TEXT.strip_heredoc.chomp.squish) }
     Please provide the amount spent on printers in 2020.
+    PDF
     TEXT
   end
 
@@ -148,8 +157,14 @@ RSpec.describe CaseManagement::Icasework::PublishedRequest, type: :model do
 
     let(:summary) do
       <<-TEXT.strip_heredoc.chomp.squish
-      Please provide the amount spent on printers in 2020.
+      Please provide the amount spent on printers in 2020. PDF
       TEXT
+    end
+
+    before do
+      expect(request).
+        to receive(:documents).
+        and_return([double(pdf_contents: 'PDF')])
     end
 
     it do


### PR DESCRIPTION
- [x] Requires https://github.com/mysociety/foi-for-councils/pull/421.

Extracts the PDF contents of documents to add to the summary text for
searchability.

Fixes https://github.com/mysociety/foi-for-councils/issues/386.