### PR TITLE
Fix GitHub action libv8 install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,20 +53,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-
-    - name: Cache RubyGems
-      uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-${{ matrix.ruby }}-gems-unit-${{ hashFiles(format('{0}.lock', matrix.gemfile || 'Gemfile')) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.ruby }}-gems-unit-
-
-    - name: Install RubyGems
-      run: |
-        bundle config path vendor/bundle
-        bundle config build.libv8 --with-system-v8
-        bundle install --jobs $(nproc) --retry 3
+        bundler-cache: true
 
     - name: Setup database
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler: 2.1.4
         bundler-cache: true
 
     - name: Setup database


### PR DESCRIPTION
Uses Bundler 2.1 instead of 2.2 - so the prepackaged libv8 binary is used.

This reverts commit 9be97431cb61f4c3211b081d119328f84057e0cf.