### PR TITLE
Add iCasework admin help page

### DIFF
--- a/app/controllers/admin/help_controller.rb
+++ b/app/controllers/admin/help_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Admin
+  ##
+  # Provide inline help to remind Admins how to use the system.
+  #
+  class HelpController < AdminController
+    def index
+      @case_management = CaseManagement.current
+    end
+  end
+end

--- a/app/models/case_management/icasework.rb
+++ b/app/models/case_management/icasework.rb
@@ -59,6 +59,10 @@ module CaseManagement
       ).url
     end
 
+    def to_partial_path
+      name.underscore
+    end
+
     protected
 
     attr_reader :client

--- a/app/models/case_management/infreemation.rb
+++ b/app/models/case_management/infreemation.rb
@@ -49,6 +49,10 @@ module CaseManagement
       published_request.url
     end
 
+    def to_partial_path
+      name.underscore
+    end
+
     protected
 
     attr_reader :client

--- a/app/views/admin/help/_breadcrumb.html.erb
+++ b/app/views/admin/help/_breadcrumb.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <a href="<%= admin_help_path %>">Help</a>
+</li>

--- a/app/views/admin/help/case_management/_icasework.html.erb
+++ b/app/views/admin/help/case_management/_icasework.html.erb
@@ -1,0 +1,63 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h2 class="heading-medium">
+      Using iCasework Published Requests as Suggestions
+    </h2>
+
+    <p class="lede">
+      FOI Works makes your responses to FOI requests work a little harder.
+    </p>
+
+    <p>
+      By publishing responses in iCasework, FOI Works automatically imports
+      them to use as Suggestions that get presented to citizens when
+      they&rsquo;re making a similar request. This helps reduce FOI requests by
+      guiding citizens towards pre-existing information.
+    </p>
+
+    <p class="notice">
+      <i class="icon icon-important">
+        <span class="visually-hidden">Warning</span>
+      </i>
+
+      <strong class="bold-small">
+        Suggestions use data directly extracted from iCasework.  You must ensure
+        that no Personally Identifiable Information (PII) is revealed:
+      </strong>
+    </p>
+
+    <p>
+      When publishing a request in iCasework, you must:
+    </p>
+
+    <ul class="list list-bullet font-xsmall">
+      <li>
+        Remove PII from the case &ldquo;Details&rdquo;. You can always go
+        back to view the full original details that were submitted.
+      </li>
+
+      <li>
+        Ensure a single, redacted, PDF response document is published. The
+        document name needs to be one of:
+
+        <ul class="list list-bullet font-xsmall">
+          <li>
+            <code>Response (all information to be supplied)</code>
+          </li>
+          <li>
+            <code>Response (some exempt)</code>
+          </li>
+          <li>
+            <code>Response (some not held)</code>
+          </li>
+        </ul>
+      </li>
+
+      <li>
+        Ensure that response document is marked as &ldquo;allowed for self
+        service&rdquo;.
+      </li>
+    </ul>
+  </div>
+</div>
+

--- a/app/views/admin/help/index.html.erb
+++ b/app/views/admin/help/index.html.erb
@@ -1,0 +1,14 @@
+<% content_for :page_title, 'Help' %>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h1 class="heading-xlarge">
+      Help
+    </h1>
+
+    <div id="content">
+      <%= render partial: "admin/help/#{@case_management.to_partial_path}" %>
+    </div>
+  </div>
+</div>
+

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -4,6 +4,7 @@
     <ul class="list list-bullet font-small">
       <li><%= link_to 'Curated Links', admin_curated_links_path %></li>
       <li><%= link_to 'Performance', admin_performance_path %></li>
+      <li><%= link_to 'Help', admin_help_path %></li>
     </ul>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     end
 
     resource :performance, only: %i[show new create]
+
+    get 'help', to: 'help#index', as: :help
   end
 
   namespace :health do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,15 @@ Rails.application.routes.draw do
 
   namespace :foi do
     root to: 'requests#index'
+
     resource :request, except: %i[show destroy] do
       root to: redirect('foi/request/new')
+
       resources :suggestions, only: %i[index]
+
       get 'contact', to: redirect('foi/request/contact/new')
       resource :contact, except: %i[show destroy]
+
       get 'preview', to: 'submissions#new', as: 'preview'
       post 'send', to: 'submissions#create', as: 'send'
       get 'sent', to: 'submissions#show', as: 'sent'
@@ -23,16 +27,19 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root action: 'show'
+
     resources :curated_links, except: [:show] do
       collection do
         resource :export, only: [:show], format: 'csv'
       end
     end
+
     resource :performance, only: %i[show new create]
   end
 
   namespace :health do
     root to: redirect('/health/metrics')
+
     resources :metrics, only: [:index], format: 'txt'
   end
 

--- a/spec/controllers/admin/help_controller_spec.rb
+++ b/spec/controllers/admin/help_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::HelpController, type: :controller do
+  let(:session) do
+    { current_user: 123, authenticated_until: (Time.zone.now + 1.hour).to_i }
+  end
+
+  before do
+    allow(User).to receive(:find_by).with(uid: 123).and_return(build(:user))
+  end
+
+  describe 'GET #index' do
+    subject { get :index, session: session }
+
+    before { CaseManagement.current = case_management }
+    after { CaseManagement.current = nil }
+
+    let(:case_management) do
+      double(to_partial_path: 'case_management/icasework')
+    end
+
+    it 'returns http success' do
+      is_expected.to have_http_status(200)
+    end
+  end
+end

--- a/spec/models/case_management/icasework_spec.rb
+++ b/spec/models/case_management/icasework_spec.rb
@@ -149,4 +149,9 @@ RSpec.describe CaseManagement::Icasework, type: :model do
 
     it { is_expected.to eq('https://example.com/doc/D225851') }
   end
+
+  describe '#to_partial_path' do
+    subject { described_class.new.to_partial_path }
+    it { is_expected.to eq('case_management/icasework') }
+  end
 end

--- a/spec/models/case_management/infreemation_spec.rb
+++ b/spec/models/case_management/infreemation_spec.rb
@@ -92,4 +92,9 @@ RSpec.describe CaseManagement::Infreemation, type: :model do
     let(:published_request) { double(url: 'https://example.com') }
     it { is_expected.to eq('https://example.com') }
   end
+
+  describe '#to_partial_path' do
+    subject { described_class.new.to_partial_path }
+    it { is_expected.to eq('case_management/infreemation') }
+  end
 end

--- a/spec/views/admin/help/index.html.erb_spec.rb
+++ b/spec/views/admin/help/index.html.erb_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'admin/help/index', type: :view do
+  let(:case_management) do
+    double(to_partial_path: 'case_management/icasework')
+  end
+
+  it 'renders the partial for the assigned case management' do
+    assign :case_management, case_management
+    render
+    expect(rendered).to match(/icasework/i)
+  end
+end


### PR DESCRIPTION
Add basic admin help for iCasework

Reminders for how to use iCasework published requests as Suggestions.

<img width="1232" alt="Screenshot 2021-04-08 at 10 05 40" src="https://user-images.githubusercontent.com/282788/113999637-1f039200-9852-11eb-97d8-703f8b060e29.png">

I haven't implemented an Infreemation help page because it's not currently in use. This will obviously break if we do use Infreemation again, so we'll need to add `app/views/admin/help/case_management/_infreemation.html.erb` at that point.