### PR TITLE
Unlock Sidekiq gem version to allow upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
     open-pull-requests-limit: 99
     rebase-strategy: "disabled"
     ignore:
-      # requires Redis 4+
-      - dependency-name: sidekiq
-        versions:
-        - ">= 6.0.0"
       # incompatible with hackney_template
       - dependency-name: sass-rails
         versions:

--- a/Gemfile
+++ b/Gemfile
@@ -42,9 +42,9 @@ gem 'icasework'
 gem 'infreemation'
 
 # Background workers
-gem 'redis', '~> 4.1.0'
+gem 'redis'
 gem 'redis-namespace'
-gem 'sidekiq', '~> 5.2'
+gem 'sidekiq'
 gem 'sidekiq-scheduler'
 
 # Error reporting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 5.6)
   rails (~> 6.1.0)
-  redis (~> 4.1.0)
+  redis
   redis-namespace
   rspec-rails (~> 5.0)
   rubocop
@@ -388,7 +388,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (~> 5.1.0)
   scenic
-  sidekiq (~> 5.2)
+  sidekiq
   sidekiq-scheduler
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -386,7 +386,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 5.6)
   rails!
-  redis (~> 4.1.0)
+  redis
   redis-namespace
   rspec-rails (~> 5.0)
   rubocop
@@ -394,7 +394,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (~> 5.1.0)
   scenic
-  sidekiq (~> 5.2)
+  sidekiq
   sidekiq-scheduler
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
We now run Redis Server v6 so we can upgrade to later Sidekiq versions.

This reverts part of commit 9d25b1e1b0b2f8bed10f57a57d12b54a5f6650f3.