### PR TITLE
Bump icasework gem to v0.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    icasework (0.1.1)
+    icasework (0.1.2)
       activesupport (>= 4.0.0)
       jwt (~> 2.2.0)
       nokogiri (~> 1.0)


### PR DESCRIPTION
For fixes to https://github.com/mysociety/icasework-ruby/issues/119